### PR TITLE
Support translation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ Cargo.lock
 **/*.rs.bk
 
 *lang
+
+/build
+
+__pycache__

--- a/README.md
+++ b/README.md
@@ -23,6 +23,142 @@ cd procelio-translation
 
 (For creating a new file, you can also copy-paste the English pack and overwrite data as necessary)
 
+## Repository Layout
+
+This repository separates translation text, shared styling, local styling, templates and generated output.
+
+Source files:
+- `files/ENGLISH/language.json`: canonical English text and metadata
+- `files/<LANGUAGE>/language.json`: translated text and metadata for a language
+- `files/shared_style.json`: shared style baseline for the whole repository
+- `files/<LANGUAGE>/style.json`: optional per-language style overrides
+- `files/<LANGUAGE>/image.png`: language flag or icon
+- `files/<LANGUAGE>/glossary.json`: optional automation glossary for translation runs
+- `files/<LANGUAGE>/translation_cache.json`: optional automation cache for translation runs
+
+Generated output:
+- `build/<LANGUAGE>/language.json`
+- `build/<LANGUAGE>/image.png`
+
+Templates copied by scripts:
+- `templates/style.json`
+- `templates/glossary.json`
+
+## Automated Translation Script
+
+For a faster first draft, this repository also includes `auto_translate.py`.
+
+What it does:
+- Creates or reuses a temporary Python virtual environment
+- Installs the required translation package (`deep-translator`) if it is missing
+- Reads `files/ENGLISH/language.json`
+- Creates or updates `files/<LANGUAGE>/language.json`
+- Copies `files/ENGLISH/image.png` if the target image does not exist yet
+- Ensures `files/<LANGUAGE>/style.json` exists
+- Ensures `files/<LANGUAGE>/glossary.json` exists
+- Reuses a per-language glossary and translation cache when available
+
+### Requirements
+- Python 3 with the `venv` module available
+- Internet access while generating translations
+
+### Example usage
+```bash
+python3 auto_translate.py GERMAN \
+  --target-code de \
+  --anglicized-name German \
+  --native-name Deutsch \
+  --authors "Your Name"
+```
+
+```bash
+python3 auto_translate.py FRENCH \
+  --target-code fr \
+  --anglicized-name French \
+  --native-name Français \
+  --authors "Your Name"
+```
+
+Only rebuild the translation cache:
+```bash
+python3 auto_translate.py GERMAN --rebuild-cache-only
+```
+
+### Reusable glossary and cache
+
+The script stores reusable automation files inside the target language folder:
+- `files/<LANGUAGE>/glossary.json`
+- `files/<LANGUAGE>/translation_cache.json`
+- `files/<LANGUAGE>/style.json`
+
+#### `glossary.json`
+This file is for manual control over wording.
+
+It supports:
+- `by_key`: exact override by internal entry name
+- `by_source_text`: exact override by original English text
+- `post_replace`: simple find/replace pairs applied after translation
+
+#### `translation_cache.json`
+This file stores previously translated source strings so later runs can reuse them instead of retranslating identical English text.
+
+That means:
+- repeated strings become more consistent
+- reruns are faster
+- you can improve a pack over time without losing prior work
+- on each script run, the cache is refreshed from the current target `language.json` unless you use `--no-reuse-existing`
+
+### Helpful options
+- `--force-retranslate`: ignore cached translations and translate again
+- `--no-reuse-existing`: do not seed the cache from an existing target `language.json`
+- `--glossary-path PATH`: use a different glossary file
+- `--cache-path PATH`: use a different cache file
+- `--write-glossary-template-only`: create the glossary file and stop
+- `--rebuild-cache-only`: rebuild `translation_cache.json` from the current target `language.json` and stop
+
+### Notes
+- The script is best used for creating a first draft, not as a final replacement for manual review.
+- Rich-text tags, placeholders like `%s`, and keybind tokens like `${DriveShoot}` are (/should be) preserved automatically.
+
+## Shared Style Pipeline
+
+To separate translated text from presentation styling, this repository uses:
+- a shared style baseline in `files/shared_style.json`
+- optional per-language overrides in `files/<LANGUAGE>/style.json`
+
+This setup exists because:
+- most style fields are usually identical across languages
+- some languages still need one-off overrides for size, alignment, or emphasis
+- keeping shared style separate reduces duplication and keeps `language.json` focused on text
+
+### Build merged output
+Use `build_language_pack.py` to generate a final Unity/proceliotool-ready pack:
+
+```bash
+python3 build_language_pack.py GERMAN
+```
+
+This writes:
+- `build/GERMAN/language.json`
+- `build/GERMAN/image.png`
+
+If you omit the language argument, the script builds every language folder found in `files/`:
+
+```bash
+python3 build_language_pack.py
+```
+
+Merge order:
+1. canonical entry list from `files/ENGLISH/language.json`
+2. translated values from `files/<LANGUAGE>/language.json`, falling back to English where entries are missing
+3. shared style from `files/shared_style.json`
+4. per-language overrides from `files/<LANGUAGE>/style.json`
+
+### Recommendation
+- Keep translated wording in `files/<LANGUAGE>/language.json`
+- Put only true language-specific presentation changes into `files/<LANGUAGE>/style.json`
+- Treat `build/<LANGUAGE>/language.json` as generated output, not as the place to edit translations manually
+
 #### Deployment
 
 For mass-release, lang files must be built and deployed serverside by one of the devs.
@@ -30,13 +166,19 @@ For mass-release, lang files must be built and deployed serverside by one of the
 For local testing, your built .lang file can be put in the `localization` subfolder in Unity's PersistentDataPath. (`C:\Users\brenn\AppData\LocalLow\Procul Games\Procelio\localization\English.lang`, for example, on Windows). If the folder doesn't exist, you can create it yourself. Run Procelio, and the file should be visible in Settings -> Game Settings -> Language
 
 ## Customizing Translation Files
-Each translation file consists of two pieces:
-1) The JSON file, where all of the data is defined for the translation
-2) The PNG Image file, which should appear next to the native name in the translation menu (expected to be a country flag)
 
-### The JSON file: language.json
-The "language.json" file holds all of the translation data for this translation.
-This file contains a bit of metadata, then a large list of language elements that define the actual user interface text.
+Each language pack consists of multiple files:
+1. `language.json`: text and language metadata
+2. `style.json`: optional style overrides for this language only
+3. `image.png`: the image shown next to the language in the menu
+4. `glossary.json`: optional automation glossary
+5. `translation_cache.json`: optional automation cache
+
+There is also one shared repository-wide style file:
+- `files/shared_style.json`
+
+And one generated output location:
+- `build/<LANGUAGE>/language.json`
 
 Note: "logbook" entries are provided by default but are considered optional as some can be very long. Feel free to simply delete any entries that you don't want to fill out.
 
@@ -54,30 +196,21 @@ You! Whatever attribution you want for putting in the work here (name, username,
 ##### version
 The version of this translation file. Should be increased whenever a new release is ready
 
-#### Language Elements
-For saving space, only the field_name and field_value values are generated by default.
-If further alternations are required, various parameters of the text can be modified by adding the corresponding fields.
+### The Text File: language.json
+`language.json` is a text-first file.
 
-Here is a fully-specified text element
+It contains:
+- language metadata
+- a `language_elements` array
+- per entry, only `name` and `value`
+
+Example entry:
 ```
 {
-      "name": "SOME_TEXT_FIELD",
-      "value": "Some Text Value In Game",
-      "size": 0,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [
-        255,
-        255,
-        255
-      ]
+  "name": "SOME_TEXT_FIELD",
+  "value": "Some Text Value In Game"
 }
 ```
-
-Descriptions of each field are as follows:
 
 ##### name
 The internal name of the field, used so the game can tell which UI element this goes with.
@@ -85,6 +218,27 @@ DO NOT CHANGE
 
 ##### value
 The text of the UI element. You almost certainly want to change this. If empty, falls back to default English value
+
+### The Style File: style.json
+`style.json` contains only language-specific style overrides keyed by entry name.
+
+Example:
+```json
+{
+  "meta": {
+    "description": "Optional style overrides applied on top of files/shared_style.json"
+  },
+  "by_key": {
+    "SOME_TEXT_FIELD": {
+      "size": 28,
+      "bold": true,
+      "alignment": 5
+    }
+  }
+}
+```
+
+Supported style properties:
 
 ##### size
 In case it's necessary to overwrite the size of the text. 0 = default. 1024 max value. Must be positive.
@@ -130,8 +284,23 @@ The alignment to use for text. If unspecified, treated as 0 (i.e. don't override
 What color the text should be in-game
 If unspecified, treated as white '[255, 255, 255]'. Each number is the respective one-byte R,G,B channel
 
+### The Shared Style File: shared_style.json
+`files/shared_style.json` contains the shared baseline style for the whole repository.
+
+Languages should only override this in their local `style.json` when necessary.
+
+### The Generated Build File
+`build/<LANGUAGE>/language.json` is the generated final output used for Unity/proceliotool workflows.
+
+It contains:
+- the full canonical English key set
+- translated values where available
+- English fallback values where a language is missing keys
+- shared style from `files/shared_style.json`
+- local style overrides from `files/<LANGUAGE>/style.json`
+
 ### The Image File: image.png
-A 24x48 pixel PNG image.
+A 48x24 pixel PNG image.
 Use any image editor you want to modify it, but keep the file name the same.
 
 

--- a/auto_translate.py
+++ b/auto_translate.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""
+Bootstrap and run automated Procelio translation generation.
+
+The script creates or reuses a temporary virtual environment, installs the
+required translation package, and translates a selected language pack from the
+English source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+FILES_DIR = REPO_ROOT / "files"
+TEMPLATES_DIR = REPO_ROOT / "templates"
+DEFAULT_SOURCE_DIR = "ENGLISH"
+DEFAULT_PACKAGE = "deep-translator==1.11.4"
+CHILD_ENVVAR = "PROCELIO_TRANSLATE_CHILD"
+PLACEHOLDER_RE = re.compile(r"(<[^>]+>|%[A-Z_]+%|%s|%d|\$\{[^}]+\})")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create or update a translated language pack from ENGLISH."
+    )
+    parser.add_argument(
+        "language_dir",
+        help="Target folder inside files/, for example GERMAN or FRENCH.",
+    )
+    parser.add_argument(
+        "--target-code",
+        help="Translator target code, for example de, fr, es, it.",
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=DEFAULT_SOURCE_DIR,
+        help=f"Source folder inside files/ (default: {DEFAULT_SOURCE_DIR}).",
+    )
+    parser.add_argument(
+        "--anglicized-name",
+        help="Language name in English ASCII, for example German.",
+    )
+    parser.add_argument(
+        "--native-name",
+        help="Language name in the target language, for example Deutsch.",
+    )
+    parser.add_argument(
+        "--authors",
+        help="Author attribution to write into language.json.",
+    )
+    parser.add_argument(
+        "--venv-dir",
+        default=str(Path(tempfile.gettempdir()) / "procelio-translate-venv"),
+        help="Temporary virtual environment directory.",
+    )
+    parser.add_argument(
+        "--package",
+        default=DEFAULT_PACKAGE,
+        help=f"Translation package to install in the temp venv (default: {DEFAULT_PACKAGE}).",
+    )
+    parser.add_argument(
+        "--glossary-path",
+        help="Optional glossary file path. Defaults to files/<LANG>/glossary.json.",
+    )
+    parser.add_argument(
+        "--cache-path",
+        help="Optional cache file path. Defaults to files/<LANG>/translation_cache.json.",
+    )
+    parser.add_argument(
+        "--force-retranslate",
+        action="store_true",
+        help="Ignore the stored translation cache and retranslate non-glossary values.",
+    )
+    parser.add_argument(
+        "--no-reuse-existing",
+        action="store_true",
+        help="Do not seed the cache from an existing target language.json.",
+    )
+    parser.add_argument(
+        "--no-install",
+        action="store_true",
+        help="Fail instead of installing the translation package when it is missing.",
+    )
+    parser.add_argument(
+        "--write-glossary-template-only",
+        action="store_true",
+        help="Create the glossary file if missing and exit without translating.",
+    )
+    parser.add_argument(
+        "--rebuild-cache-only",
+        action="store_true",
+        help="Refresh translation_cache.json from the current target language.json and exit.",
+    )
+    return parser.parse_args()
+
+
+def venv_python(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def run(cmd: list[str], *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(cmd, check=True, env=env)
+
+
+def ensure_bootstrap_environment(args: argparse.Namespace) -> None:
+    if os.environ.get(CHILD_ENVVAR) == "1":
+        return
+    if args.write_glossary_template_only or args.rebuild_cache_only:
+        return
+
+    venv_dir = Path(args.venv_dir)
+    python_in_venv = venv_python(venv_dir)
+
+    if not python_in_venv.exists():
+        print(f"[bootstrap] Creating temporary virtual environment at {venv_dir}")
+        run([sys.executable, "-m", "venv", str(venv_dir)])
+
+    package_name = args.package.split("==", 1)[0].replace("-", "_")
+    check_cmd = [
+        str(python_in_venv),
+        "-c",
+        (
+            "import importlib.util, sys; "
+            f"sys.exit(0 if importlib.util.find_spec('{package_name}') else 1)"
+        ),
+    ]
+    package_missing = subprocess.run(check_cmd).returncode != 0
+
+    if package_missing:
+        if args.no_install:
+            raise SystemExit(
+                f"Required package {args.package!r} is missing in {venv_dir}. "
+                "Re-run without --no-install."
+            )
+        print(f"[bootstrap] Installing {args.package} into {venv_dir}")
+        run([str(python_in_venv), "-m", "pip", "install", args.package])
+
+    child_env = dict(os.environ)
+    child_env[CHILD_ENVVAR] = "1"
+    child_cmd = [str(python_in_venv), str(Path(__file__).resolve()), *sys.argv[1:]]
+    run(child_cmd, env=child_env)
+    raise SystemExit(0)
+
+
+def default_glossary_path(language_dir: str) -> Path:
+    return FILES_DIR / language_dir / "glossary.json"
+
+
+def default_cache_path(language_dir: str) -> Path:
+    return FILES_DIR / language_dir / "translation_cache.json"
+
+
+def default_style_path(language_dir: str) -> Path:
+    return FILES_DIR / language_dir / "style.json"
+
+
+def read_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def copy_template_if_missing(path: Path, template_name: str) -> dict[str, Any]:
+    if not path.exists():
+        template_path = TEMPLATES_DIR / template_name
+        if not template_path.exists():
+            raise SystemExit(f"Template file does not exist: {template_path}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(template_path, path)
+    return read_json(path)
+
+
+def ensure_glossary(path: Path) -> dict[str, Any]:
+    payload = copy_template_if_missing(path, "glossary.json")
+
+    payload.setdefault("meta", {})
+    payload.setdefault("by_key", {})
+    payload.setdefault("by_source_text", {})
+    payload.setdefault("post_replace", [])
+    return payload
+
+
+def protect_text(text: str) -> tuple[str, list[tuple[str, str]]]:
+    replacements: list[tuple[str, str]] = []
+
+    def replace(match: re.Match[str]) -> str:
+        token = f"__PROCELIO_TOKEN_{len(replacements)}__"
+        replacements.append((token, match.group(0)))
+        return token
+
+    return PLACEHOLDER_RE.sub(replace, text), replacements
+
+
+def unprotect_text(text: str, replacements: list[tuple[str, str]]) -> str:
+    for token, original in replacements:
+        text = text.replace(token, original)
+    return text
+
+
+def apply_post_replace(text: str, glossary: dict[str, Any]) -> str:
+    for pair in glossary.get("post_replace", []):
+        if not isinstance(pair, list) or len(pair) != 2:
+            continue
+        before, after = pair
+        text = text.replace(before, after)
+    return text
+
+
+def build_existing_translation_map(
+    source_data: dict[str, Any],
+    target_data: dict[str, Any] | None,
+) -> dict[str, str]:
+    if not target_data:
+        return {}
+
+    target_by_name = {
+        entry["name"]: entry
+        for entry in target_data.get("language_elements", [])
+        if "name" in entry
+    }
+    mapping: dict[str, str] = {}
+    for source_entry in source_data.get("language_elements", []):
+        target_entry = target_by_name.get(source_entry["name"])
+        if not target_entry:
+            continue
+        source_value = source_entry.get("value", "")
+        target_value = target_entry.get("value", "")
+        if source_value and target_value and source_value != target_value:
+            mapping.setdefault(source_value, target_value)
+    return mapping
+
+
+def rebuild_cache_from_existing_translation(
+    source_data: dict[str, Any],
+    target_data: dict[str, Any] | None,
+    existing_cache: dict[str, str] | None = None,
+) -> dict[str, str]:
+    refreshed_cache = dict(existing_cache or {})
+    refreshed_cache.update(build_existing_translation_map(source_data, target_data))
+    return refreshed_cache
+
+
+def import_translator() -> Any:
+    if importlib.util.find_spec("deep_translator") is None:
+        raise SystemExit(
+            "deep-translator is not available in the current environment. "
+            "Re-run the script without --no-install so it can bootstrap itself."
+        )
+    from deep_translator import GoogleTranslator  # type: ignore
+
+    return GoogleTranslator
+
+
+def translate_value(
+    translator: Any,
+    text: str,
+    glossary: dict[str, Any],
+    cache: dict[str, str],
+    *,
+    key_name: str,
+    force_retranslate: bool,
+) -> str:
+    if key_name in glossary["by_key"]:
+        return glossary["by_key"][key_name]
+    if text in glossary["by_source_text"]:
+        return glossary["by_source_text"][text]
+    if not text:
+        return text
+    if not force_retranslate and text in cache:
+        return apply_post_replace(cache[text], glossary)
+
+    protected_text, replacements = protect_text(text)
+
+    for attempt in range(5):
+        try:
+            translated = translator.translate(protected_text)
+            break
+        except Exception as exc:  # pragma: no cover - network dependent
+            if attempt == 4:
+                raise SystemExit(f"Translation failed for {key_name!r}: {exc}") from exc
+            time.sleep(1.5 * (attempt + 1))
+    translated = unprotect_text(translated, replacements)
+    translated = apply_post_replace(translated, glossary)
+    cache[text] = translated
+    return translated
+
+
+def build_target_entry(
+    source_entry: dict[str, Any],
+    translated_value: str,
+) -> dict[str, Any]:
+    return {"name": source_entry["name"], "value": translated_value}
+
+
+def translate_language(args: argparse.Namespace) -> None:
+    source_dir = FILES_DIR / args.source_dir
+    target_dir = FILES_DIR / args.language_dir
+    source_json = source_dir / "language.json"
+    source_image = source_dir / "image.png"
+    target_json = target_dir / "language.json"
+    target_image = target_dir / "image.png"
+
+    if not source_json.exists():
+        raise SystemExit(f"Source language file does not exist: {source_json}")
+    if not source_image.exists():
+        raise SystemExit(f"Source image file does not exist: {source_image}")
+
+    glossary_path = (
+        Path(args.glossary_path)
+        if args.glossary_path
+        else default_glossary_path(args.language_dir)
+    )
+    style_path = default_style_path(args.language_dir)
+    cache_path = (
+        Path(args.cache_path) if args.cache_path else default_cache_path(args.language_dir)
+    )
+
+    glossary = ensure_glossary(glossary_path)
+    copy_template_if_missing(style_path, "style.json")
+    if args.write_glossary_template_only:
+        print(f"Wrote glossary template to {glossary_path}")
+        print(f"Ensured style template at {style_path}")
+        return
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    if not target_image.exists():
+        shutil.copy2(source_image, target_image)
+
+    source_data = read_json(source_json)
+    existing_target = read_json(target_json) if target_json.exists() else None
+    cache = read_json(cache_path) if cache_path.exists() else {}
+
+    if not args.no_reuse_existing:
+        cache = rebuild_cache_from_existing_translation(
+            source_data,
+            existing_target,
+            cache,
+        )
+
+    if args.rebuild_cache_only:
+        write_json(cache_path, cache)
+        print(f"Rebuilt cache for {args.language_dir} from current language.json")
+        print(f"cache: {cache_path}")
+        return
+
+    if not args.target_code:
+        raise SystemExit("--target-code is required unless --rebuild-cache-only is used.")
+
+    GoogleTranslator = import_translator()
+    translator = GoogleTranslator(source="en", target=args.target_code)
+
+    existing_by_name = (
+        {
+            entry["name"]: entry
+            for entry in existing_target.get("language_elements", [])
+            if "name" in entry
+        }
+        if existing_target
+        else {}
+    )
+
+    translated_elements = []
+    unique_translated = 0
+    for source_entry in source_data.get("language_elements", []):
+        source_value = source_entry.get("value", "")
+        translated_value = translate_value(
+            translator,
+            source_value,
+            glossary,
+            cache,
+            key_name=source_entry["name"],
+            force_retranslate=args.force_retranslate,
+        )
+        if source_value and source_value not in glossary["by_source_text"]:
+            unique_translated += int(source_value in cache)
+        translated_elements.append(
+            build_target_entry(
+                source_entry,
+                translated_value,
+            )
+        )
+
+    output = copy.deepcopy(source_data)
+    output["language_elements"] = translated_elements
+    output["anglicized_name"] = (
+        args.anglicized_name
+        or (existing_target or {}).get("anglicized_name")
+        or args.language_dir.title()
+    )
+    output["native_name"] = (
+        args.native_name
+        or (existing_target or {}).get("native_name")
+        or args.language_dir.title()
+    )
+    output["authors"] = (
+        args.authors
+        or (existing_target or {}).get("authors")
+        or "Unknown"
+    )
+    if existing_target and "version" in existing_target:
+        output["version"] = existing_target["version"]
+
+    write_json(target_json, output)
+    write_json(cache_path, cache)
+
+    print(f"Translated {args.language_dir} from {args.source_dir}")
+    print(f"language.json: {target_json}")
+    print(f"image.png:      {target_image}")
+    print(f"glossary:       {glossary_path}")
+    print(f"cache:          {cache_path}")
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_bootstrap_environment(args)
+    translate_language(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_language_pack.py
+++ b/build_language_pack.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Build a Unity-ready language pack by merging:
+1) translated text from files/<LANG>/language.json
+2) shared baseline styles from files/shared_style.json
+3) optional per-language overrides from files/<LANG>/style.json
+
+The script writes a generated output folder
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+FILES_DIR = REPO_ROOT / "files"
+DEFAULT_SHARED_STYLE = FILES_DIR / "shared_style.json"
+DEFAULT_SOURCE_LANGUAGE = "ENGLISH"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a merged language pack folder for Unity/proceliotool."
+    )
+    parser.add_argument(
+        "language_dir",
+        nargs="?",
+        help="Language folder inside files/, for example GERMAN.",
+    )
+    parser.add_argument(
+        "--shared-style",
+        default=str(DEFAULT_SHARED_STYLE),
+        help=f"Shared style baseline file (default: {DEFAULT_SHARED_STYLE}).",
+    )
+    parser.add_argument(
+        "--source-language",
+        default=DEFAULT_SOURCE_LANGUAGE,
+        help=f"Canonical source language folder used to fill missing entries (default: {DEFAULT_SOURCE_LANGUAGE}).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Output directory. Defaults to build/<LANGUAGE>/.",
+    )
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> Any:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def merge_language_pack(args: argparse.Namespace) -> None:
+    source_dir = FILES_DIR / args.source_language
+    source_json = source_dir / "language.json"
+    language_dir = FILES_DIR / args.language_dir
+    language_json = language_dir / "language.json"
+    style_json = language_dir / "style.json"
+    image_png = language_dir / "image.png"
+    shared_style_json = Path(args.shared_style)
+
+    if not source_json.exists():
+        raise SystemExit(f"Source language file does not exist: {source_json}")
+    if not language_json.exists():
+        raise SystemExit(f"Language file does not exist: {language_json}")
+    if not image_png.exists():
+        raise SystemExit(f"Image file does not exist: {image_png}")
+    if not shared_style_json.exists():
+        raise SystemExit(f"Shared style file does not exist: {shared_style_json}")
+
+    source_data = read_json(source_json)
+    language_data = read_json(language_json)
+    shared_style_data = read_json(shared_style_json)
+    shared_by_key = shared_style_data.get("by_key", {})
+
+    language_style_data = read_json(style_json) if style_json.exists() else {"by_key": {}}
+    lang_by_key = language_style_data.get("by_key", {})
+
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else REPO_ROOT / "build" / args.language_dir
+    )
+    output_json = output_dir / "language.json"
+    output_image = output_dir / "image.png"
+
+    source_by_name = {
+        entry["name"]: entry for entry in source_data.get("language_elements", [])
+    }
+    language_by_name = {
+        entry["name"]: entry for entry in language_data.get("language_elements", [])
+    }
+
+    merged = copy.deepcopy(language_data)
+    merged_elements = []
+
+    for source_entry in source_data.get("language_elements", []):
+        name = source_entry["name"]
+        entry = language_by_name.get(name, source_entry)
+        merged_entry = {"name": name, "value": entry.get("value", source_entry.get("value", ""))}
+
+        # shared baseline from English
+        shared_style = shared_by_key.get(name, {})
+        for key, value in shared_style.items():
+            merged_entry[key] = value
+
+        # language-specific style.json overrides
+        style_override = lang_by_key.get(name, {})
+        for key, value in style_override.items():
+            merged_entry[key] = value
+
+        merged_elements.append(merged_entry)
+
+    merged["language_elements"] = merged_elements
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_json, merged)
+    shutil.copy2(image_png, output_image)
+
+    print(f"Built merged pack for {args.language_dir}")
+    print(f"language.json: {output_json}")
+    print(f"image.png:      {output_image}")
+    print(f"shared style:   {shared_style_json}")
+    print(f"style override: {style_json}")
+
+
+def main() -> None:
+    args = parse_args()
+    if args.language_dir:
+        merge_language_pack(args)
+        return
+
+    language_dirs = sorted(
+        path.name
+        for path in FILES_DIR.iterdir()
+        if path.is_dir() and (path / "language.json").exists() and (path / "image.png").exists()
+    )
+    if not language_dirs:
+        raise SystemExit("No language folders with language.json and image.png were found.")
+
+    for language_dir in language_dirs:
+        child_args = argparse.Namespace(**vars(args))
+        child_args.language_dir = language_dir
+        if child_args.output_dir:
+            child_args.output_dir = str(Path(child_args.output_dir) / language_dir)
+        merge_language_pack(child_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/files/ENGLISH/language.json
+++ b/files/ENGLISH/language.json
@@ -6,14832 +6,6371 @@
   "language_elements": [
     {
       "name": "dialogue-okay",
-      "value": "OK",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "OK"
     },
     {
       "name": "dialogue-success",
-      "value": "Success!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Success!"
     },
     {
       "name": "terms-changed-header",
-      "value": "Terms of Use Updated",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Terms of Use Updated"
     },
     {
       "name": "terms-changed-description",
-      "value": "Procelio's terms of use have changed and required additional agreement to play the game.\n\nSee <link=\"%PRIVACY%\"><color=blue>Privacy Policy</color></link>\nSee <link=\"%TOS%\"><color=blue>Terms of Service</color></link>\n\nDo you agree to the above-linked documents?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Procelio's terms of use have changed and required additional agreement to play the game.\n\nSee <link=\"%PRIVACY%\"><color=blue>Privacy Policy</color></link>\nSee <link=\"%TOS%\"><color=blue>Terms of Service</color></link>\n\nDo you agree to the above-linked documents?"
     },
     {
       "name": "login-failed-title",
-      "value": "Login Failed",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Login Failed"
     },
     {
       "name": "login-badcreds-description",
-      "value": "Bad login credentials",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Bad login credentials"
     },
     {
       "name": "login-sessionexpired-description",
-      "value": "Cached session expired",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cached session expired"
     },
     {
       "name": "login-networkfail-description",
-      "value": "Network failure",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Network failure"
     },
     {
       "name": "login-servererror-description",
-      "value": "Internal server error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Internal server error"
     },
     {
       "name": "login-failedtosteam-description",
-      "value": "Failed to query Steam",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to query Steam"
     },
     {
       "name": "loading-title",
-      "value": "Loading Data...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Loading Data..."
     },
     {
       "name": "loading-server-description",
-      "value": "Checking for updated part statistics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Checking for updated part statistics"
     },
     {
       "name": "loading-assets-description",
-      "value": "Loading asset data",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Loading asset data"
     },
     {
       "name": "loading-player-description",
-      "value": "Downloading player account state",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Downloading player account state"
     },
     {
       "name": "loading-robots-description",
-      "value": "Downloading player robots state",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Downloading player robots state"
     },
     {
       "name": "loading-error-title",
-      "value": "Error Loading Data",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Error Loading Data"
     },
     {
       "name": "loading-error-stats-description",
-      "value": "Unable to download stats file",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to download stats file"
     },
     {
       "name": "loading-error-accountstate-description",
-      "value": "Unable to download account server state",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to download account server state"
     },
     {
       "name": "loading-error-cullbots-description",
-      "value": "Unable to download AI bot files",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to download AI bot files"
     },
     {
       "name": "loading-error-techtree-description",
-      "value": "Unable to fetch active tech tree",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to fetch active tech tree"
     },
     {
       "name": "conn-files-failed-header",
-      "value": "Connection Failed",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Connection Failed"
     },
     {
       "name": "conn-files-failed-description",
-      "value": "Unable to connect to files server",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to connect to files server"
     },
     {
       "name": "acct-create-err-header",
-      "value": "Account Creation Error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Account Creation Error"
     },
     {
       "name": "acct-create-err-pwmismatch-description",
-      "value": "Provided passwords do not match",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Provided passwords do not match"
     },
     {
       "name": "acct-create-err-noagreement-description",
-      "value": "You must agree to the terms of use to play Procelio",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "You must agree to the terms of use to play Procelio"
     },
     {
       "name": "acct-create-err-pwtoolong-description",
-      "value": "Password too long. Please limit to 128 characters/bytes",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Password too long. Please limit to 128 characters/bytes"
     },
     {
       "name": "acct-create-err-pwtooshort-description",
-      "value": "Password too short. Must be at least 8 characters long",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Password too short. Must be at least 8 characters long"
     },
     {
       "name": "acct-create-err-usertoolong-description",
-      "value": "Username too long. May be at most 28 characters",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Username too long. May be at most 28 characters"
     },
     {
       "name": "acct-create-err-userbad-description",
-      "value": "Username may only contain valid ASCII graphical characters",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Username may only contain valid ASCII graphical characters"
     },
     {
       "name": "acct-create-err-usernaughty-description",
-      "value": "Username flagged by content filter",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Username flagged by content filter"
     },
     {
       "name": "acct-create-err-emailused-description",
-      "value": "Email already in use",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Email already in use"
     },
     {
       "name": "acct-create-err-userused-description",
-      "value": "Username already in use",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Username already in use"
     },
     {
       "name": "acct-create-err-bademail-description",
-      "value": "A valid email is required for password recovery\n(Disposable addresses permitted, at user's risk of account loss)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A valid email is required for password recovery\n(Disposable addresses permitted, at user's risk of account loss)"
     },
     {
       "name": "acct-create-err-network-description",
-      "value": "Network error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Network error"
     },
     {
       "name": "acct-create-err-server-description",
-      "value": "Internal server error (go yell at devs)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Internal server error (go yell at devs)"
     },
     {
       "name": "acct-create-success-description",
-      "value": "Account created! Please log in...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Account created! Please log in..."
     },
     {
       "name": "acct-create-err-steamfail-description",
-      "value": "Failed to connect to Steam",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to connect to Steam"
     },
     {
       "name": "acct-link-err-steamlink-description",
-      "value": "Account already linked to Steam",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Account already linked to Steam"
     },
     {
       "name": "acct-link-err-standalonelink-description",
-      "value": "Account already has standalone credentials",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Account already has standalone credentials"
     },
     {
       "name": "acct-link-err-steamconflict-description",
-      "value": "Steam already linked to a different account",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Steam already linked to a different account"
     },
     {
       "name": "acct-link-err-authfail-description",
-      "value": "Failed to authenticate Steam account",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to authenticate Steam account"
     },
     {
       "name": "confirm-graphics-title",
-      "value": "Confirm graphics settings?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Confirm graphics settings?"
     },
     {
       "name": "confirm-graphics-body",
-      "value": "Click \"OK\" if the graphics settings are acceptable.\nSettings will revert in 10 seconds...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Click \"OK\" if the graphics settings are acceptable.\nSettings will revert in 10 seconds..."
     },
     {
       "name": "key-robotdriveforward",
-      "value": "Drive Forward",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Drive Forward"
     },
     {
       "name": "key-robotdrivebackward",
-      "value": "Drive Backward",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Drive Backward"
     },
     {
       "name": "key-robotdriveleft",
-      "value": "Strafe Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Strafe Left"
     },
     {
       "name": "key-robotdriveright",
-      "value": "Strafe Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Strafe Right"
     },
     {
       "name": "key-robotdriveup",
-      "value": "Move Up",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Move Up"
     },
     {
       "name": "key-robotdrivedown",
-      "value": "Move Down",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Move Down"
     },
     {
       "name": "key-robotpitchup",
-      "value": "Pitch Up",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Pitch Up"
     },
     {
       "name": "key-robotpitchdown",
-      "value": "Pitch Down",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Pitch Down"
     },
     {
       "name": "key-robotdriveturnleft",
-      "value": "Turn Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Turn Left"
     },
     {
       "name": "key-robotdriveturnright",
-      "value": "Turn Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Turn Right"
     },
     {
       "name": "key-robotrollleft",
-      "value": "Roll Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Roll Left"
     },
     {
       "name": "key-robotrollright",
-      "value": "Roll Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Roll Right"
     },
     {
       "name": "key-robotyawleft",
-      "value": "Yaw Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Yaw Left"
     },
     {
       "name": "key-robotyawright",
-      "value": "Yaw Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Yaw Right"
     },
     {
       "name": "key-garageplaceblock",
-      "value": "Place Block",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Place Block"
     },
     {
       "name": "key-garageremoveblock",
-      "value": "Remove Block",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Remove Block"
     },
     {
       "name": "key-mousex",
-      "value": "Mouse X",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mouse X"
     },
     {
       "name": "key-mousey",
-      "value": "Mouse Y",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mouse Y"
     },
     {
       "name": "key-uimusicmute",
-      "value": "Mute music",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mute music"
     },
     {
       "name": "key-uimusicskip",
-      "value": "Skip Current Song",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Skip Current Song"
     },
     {
       "name": "key-showcursor",
-      "value": "Show Mouse Cursor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Show Mouse Cursor"
     },
     {
       "name": "key-garagepickblock",
-      "value": "Pick Block",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Pick Block"
     },
     {
       "name": "key-garagewipecosmetics",
-      "value": "Clear block cosmetics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Clear block cosmetics"
     },
     {
       "name": "key-garagecammoveforward",
-      "value": "Garage Camera: Forward",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Camera: Forward"
     },
     {
       "name": "key-garagecammovebackward",
-      "value": "Garage Camera: Backwards",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Camera: Backwards"
     },
     {
       "name": "key-garagecamstrafeleft",
-      "value": "Garage Camera: Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Camera: Left"
     },
     {
       "name": "key-garagecamstraferight",
-      "value": "Garage Camera: Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Camera: Right"
     },
     {
       "name": "key-garagecammoveup",
-      "value": "Garage Camera: Up",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Camera: Up"
     },
     {
       "name": "key-garagecammovedown",
-      "value": "Garage Camera: Down",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Camera: Down"
     },
     {
       "name": "key-garageshiftrobotforward",
-      "value": "Shift Bot Forward",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shift Bot Forward"
     },
     {
       "name": "key-garageshiftrobotbackward",
-      "value": "Shift Bot Backward",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shift Bot Backward"
     },
     {
       "name": "key-garageshiftrobotleft",
-      "value": "Shift Bot Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shift Bot Left"
     },
     {
       "name": "key-garageshiftrobotright",
-      "value": "Shift Bot Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shift Bot Right"
     },
     {
       "name": "key-garageshiftrobotup",
-      "value": "Shift Bot Up",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shift Bot Up"
     },
     {
       "name": "key-garageshiftrobotdown",
-      "value": "Shift Bot Down",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shift Bot Down"
     },
     {
       "name": "key-garagerotaterobotleft",
-      "value": "Rotate Bot Left",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rotate Bot Left"
     },
     {
       "name": "key-garagerotaterobotright",
-      "value": "Rotate Bot Right",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rotate Bot Right"
     },
     {
       "name": "key-garagerotateghostx",
-      "value": "Manually rotate ghost X (in advanced build)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Manually rotate ghost X (in advanced build)"
     },
     {
       "name": "key-garagerotateghosty",
-      "value": "Manually rotate ghost Y (in advanced build)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Manually rotate ghost Y (in advanced build)"
     },
     {
       "name": "key-garagerotateghostz",
-      "value": "Manually rotate ghost Z (in advanced build)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Manually rotate ghost Z (in advanced build)"
     },
     {
       "name": "key-garageundoredo",
-      "value": "Undo (in advanced build)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Undo (in advanced build)"
     },
     {
       "name": "key-garageredomodifier",
-      "value": "Invert Undo (i.e. Redo) (in advanced build)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Invert Undo (i.e. Redo) (in advanced build)"
     },
     {
       "name": "key-garagechangesymmetry",
-      "value": "Change Even/Odd Mirror",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Change Even/Odd Mirror"
     },
     {
       "name": "key-garagetogglemirroractive",
-      "value": "Toggle Mirror Active",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle Mirror Active"
     },
     {
       "name": "key-garagechangeeditingmode",
-      "value": "Change Build/Paint",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Change Build/Paint"
     },
     {
       "name": "key-garageenableadvanced",
-      "value": "Enable Advanced Build Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Enable Advanced Build Mode"
     },
     {
       "name": "key-garagewipebay",
-      "value": "Wipe Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wipe Garage Bay"
     },
     {
       "name": "key-drivecheckscores",
-      "value": "View Match Scores",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "View Match Scores"
     },
     {
       "name": "key-driveflipbot",
-      "value": "Flip Bot Upright",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flip Bot Upright"
     },
     {
       "name": "key-driveshoot",
-      "value": "Shoot",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shoot"
     },
     {
       "name": "key-drivescope",
-      "value": "Scope",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Scope"
     },
     {
       "name": "key-drivezoom",
-      "value": "FoV Zoom",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "FoV Zoom"
     },
     {
       "name": "key-drivecamzoomin",
-      "value": "Zoom In",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Zoom In"
     },
     {
       "name": "key-drivecamzoomout",
-      "value": "Zoom Out",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Zoom Out"
     },
     {
       "name": "key-drivereload",
-      "value": "Reload",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Reload"
     },
     {
       "name": "key-drivedrift",
-      "value": "Brake",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Brake"
     },
     {
       "name": "key-drivecycleweapon",
-      "value": "Cycle Active Weapons",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cycle Active Weapons"
     },
     {
       "name": "key-battleentityspot",
-      "value": "Spot",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Spot"
     },
     {
       "name": "key-battleentityping",
-      "value": "Ping",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ping"
     },
     {
       "name": "key-shortcutmenu2battle",
-      "value": "MainMenu Shortcut: Battle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "MainMenu Shortcut: Battle"
     },
     {
       "name": "key-shortcutmenu2garage",
-      "value": "MainMenu Shortcut: Garage",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "MainMenu Shortcut: Garage"
     },
     {
       "name": "key-shortcutmenu2stats",
-      "value": "MainMenu Shortcut: Stats",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "MainMenu Shortcut: Stats"
     },
     {
       "name": "key-shortcutmenu2settings",
-      "value": "MainMenu Shortcut: Settings",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "MainMenu Shortcut: Settings"
     },
     {
       "name": "key-shortcutmenu2exit",
-      "value": "MainMenu Shortcut: Quit",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "MainMenu Shortcut: Quit"
     },
     {
       "name": "key-shortcutsettings2settings1",
-      "value": "Settings Shortcut: Tab 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Settings Shortcut: Tab 1"
     },
     {
       "name": "key-shortcutsettings2settings2",
-      "value": "Settings Shortcut: Tab 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Settings Shortcut: Tab 2"
     },
     {
       "name": "key-shortcutsettings2settings3",
-      "value": "Settings Shortcut: Tab 3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Settings Shortcut: Tab 3"
     },
     {
       "name": "key-shortcutsettings2settings4",
-      "value": "Settings Shortcut: Tab 4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Settings Shortcut: Tab 4"
     },
     {
       "name": "key-shortcutbuild2inventory",
-      "value": "Build Shortcut: Inventory",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Build Shortcut: Inventory"
     },
     {
       "name": "key-shortcutbuild2shop",
-      "value": "Build Shortcut: Shop",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Build Shortcut: Shop"
     },
     {
       "name": "key-shortcutbuild2tech",
-      "value": "Build Shortcut: Tech",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Build Shortcut: Tech"
     },
     {
       "name": "key-shortcutbuild2test",
-      "value": "Build Shortcut: Test",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Build Shortcut: Test"
     },
     {
       "name": "key-shortcutbuild2battle",
-      "value": "Build Shortcut: Battle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Build Shortcut: Battle"
     },
     {
       "name": "key-shortcutbuild2paint",
-      "value": "Build Shortcut: Paint",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Build Shortcut: Paint"
     },
     {
       "name": "key-shortcutbuildhotbar1",
-      "value": "Garage Shortcut: Build Hotbar 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 1"
     },
     {
       "name": "key-shortcutbuildhotbar2",
-      "value": "Garage Shortcut: Build Hotbar 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 2"
     },
     {
       "name": "key-shortcutbuildhotbar3",
-      "value": "Garage Shortcut: Build Hotbar 3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 3"
     },
     {
       "name": "key-shortcutbuildhotbar4",
-      "value": "Garage Shortcut: Build Hotbar 4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 4"
     },
     {
       "name": "key-shortcutbuildhotbar5",
-      "value": "Garage Shortcut: Build Hotbar 5",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 5"
     },
     {
       "name": "key-shortcutbuildhotbar6",
-      "value": "Garage Shortcut: Build Hotbar 6",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 6"
     },
     {
       "name": "key-shortcutbuildhotbar7",
-      "value": "Garage Shortcut: Build Hotbar 7",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 7"
     },
     {
       "name": "key-shortcutbuildhotbar8",
-      "value": "Garage Shortcut: Build Hotbar 8",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 8"
     },
     {
       "name": "key-shortcutbuildhotbar9",
-      "value": "Garage Shortcut: Build Hotbar 9",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 9"
     },
     {
       "name": "key-shortcutbuildhotbar0",
-      "value": "Garage Shortcut: Build Hotbar 0",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Shortcut: Build Hotbar 0"
     },
     {
       "name": "key-shortcuttest2damage",
-      "value": "Test Shortcut: Damage mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Test Shortcut: Damage mode"
     },
     {
       "name": "key-uiminimaptoggle",
-      "value": "Hide/Show minimap",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hide/Show minimap"
     },
     {
       "name": "key-uiminimapscale",
-      "value": "Scale minimap",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Scale minimap"
     },
     {
       "name": "key-uitogglefps",
-      "value": "Display FPS in top-left corner",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Display FPS in top-left corner"
     },
     {
       "name": "key-battlemapping",
-      "value": "Ping Minimap",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ping Minimap"
     },
     {
       "name": "key-drivemodule1",
-      "value": "Ability 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ability 1"
     },
     {
       "name": "key-drivemodule2",
-      "value": "Ability 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ability 2"
     },
     {
       "name": "key-drivemodule3",
-      "value": "Ability 3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ability 3"
     },
     {
       "name": "key-drivemodule4",
-      "value": "Ability 4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ability 4"
     },
     {
       "name": "key-drivemodule5",
-      "value": "Ability 5",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ability 5"
     },
     {
       "name": "key-drivemodule6",
-      "value": "Ability 6",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ability 6"
     },
     {
       "name": "key-functiontoggleui",
-      "value": "Toggle UI visibility",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle UI visibility"
     },
     {
       "name": "key-functionselfdestruct",
-      "value": "Self Destruct",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Self Destruct"
     },
     {
       "name": "key-robottogglecosmetics",
-      "value": "Toggle Lights / Cosmetics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle Lights / Cosmetics"
     },
     {
       "name": "key-robothorn",
-      "value": "Honk Equipped Horn",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Honk Equipped Horn"
     },
     {
       "name": "key-gizmostogglecollisionboxes",
-      "value": "Toggle Collision Box Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle Collision Box Gizmos"
     },
     {
       "name": "key-gizmostogglecenteroflift",
-      "value": "Toggle Center of Lift Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle Center of Lift Gizmos"
     },
     {
       "name": "key-gizmostogglecenterofthrust",
-      "value": "Toggle Center of Thrust Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle Center of Thrust Gizmos"
     },
     {
       "name": "key-gizmostogglecenterofmass",
-      "value": "Toggle Center of Mass Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Toggle Center of Mass Gizmos"
     },
     {
       "name": "key-gizmosdisableall",
-      "value": "Disable All Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Disable All Gizmos"
     },
     {
       "name": "key-garageraisebuildplate",
-      "value": "Raise Garage Buildplate",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Raise Garage Buildplate"
     },
     {
       "name": "key-garagelowerbuildplate",
-      "value": "Lower Garage Buildplate",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Lower Garage Buildplate"
     },
     {
       "name": "key-garageresetbuildplate",
-      "value": "Reset Garage Buildplate",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Reset Garage Buildplate"
     },
     {
       "name": "key-garagerotatebuildplate",
-      "value": "Rotate Garage Buildplate",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rotate Garage Buildplate"
     },
     {
       "name": "paint-palette-presets",
-      "value": "Preset Colors",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Preset Colors"
     },
     {
       "name": "paint-palette-standard",
-      "value": "Custom Palette #",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Custom Palette #"
     },
     {
       "name": "mapname-alpha-prospect",
-      "value": "Alpha Prospect",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Alpha Prospect"
     },
     {
       "name": "mapname-deimos-nexus",
-      "value": "Deimos Nexus",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Deimos Nexus"
     },
     {
       "name": "mapname-feldspar-valley",
-      "value": "Feldspar Valley",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Feldspar Valley"
     },
     {
       "name": "mapname-icarus-north",
-      "value": "Icarus North",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Icarus North"
     },
     {
       "name": "maplocation-home-high-mars-orbit",
-      "value": "High Mars Orbit",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "High Mars Orbit"
     },
     {
       "name": "maplocation-alpha-prospect",
-      "value": "Melas Chasma, Mars",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Melas Chasma, Mars"
     },
     {
       "name": "maplocation-deimos-nexus",
-      "value": "Pavonis Mons, Mars",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Pavonis Mons, Mars"
     },
     {
       "name": "maplocation-feldspar-valley",
-      "value": "Arcadia Dorsa, Mars",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcadia Dorsa, Mars"
     },
     {
       "name": "maplocation-icarus-north",
-      "value": "Planum Boreale, Mars",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Planum Boreale, Mars"
     },
     {
       "name": "enter-to-type",
-      "value": "Press Enter to type...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Press Enter to type..."
     },
     {
       "name": "report-cause-chatbehavior",
-      "value": "Chat (language or behavior)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Chat (language or behavior)"
     },
     {
       "name": "report-cause-obscenebot",
-      "value": "Robot '{bot}' (inappropriate/obscene)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot '{bot}' (inappropriate/obscene)"
     },
     {
       "name": "report-cause-hacking",
-      "value": "Hacking",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hacking"
     },
     {
       "name": "chat-playercount-connected",
-      "value": "CONNECTED",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "CONNECTED"
     },
     {
       "name": "techtree-category-unknown",
-      "value": "Unknown Tree",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unknown Tree"
     },
     {
       "name": "techtree-category-weaponry",
-      "value": "Weaponry",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Weaponry"
     },
     {
       "name": "techtree-category-movement",
-      "value": "Movement",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Movement"
     },
     {
       "name": "techtree-category-structure",
-      "value": "Components",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Components"
     },
     {
       "name": "techtree-category-modules",
-      "value": "Modules",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Modules"
     },
     {
       "name": "techtree-category-extras",
-      "value": "Extras",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Extras"
     },
     {
       "name": "techtree-category-progression",
-      "value": "Promotion",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Promotion"
     },
     {
       "name": "techtree-background-text",
-      "value": "PROCELIO PROGRAM REQUISITION CATALOG v1.5\nEMPLOYEE ID: %b",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PROCELIO PROGRAM REQUISITION CATALOG v1.5\nEMPLOYEE ID: %b"
     },
     {
       "name": "techtree-background-text-2",
-      "value": "FLY WITH OSPREY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "FLY WITH OSPREY"
     },
     {
       "name": "ai-objective-hunt",
-      "value": "Hunting",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hunting"
     },
     {
       "name": "ai-objective-wander",
-      "value": "Wandering",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wandering"
     },
     {
       "name": "ai-objective-objectivewait",
-      "value": "Waiting",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Waiting"
     },
     {
       "name": "ai-objective-objectivefind",
-      "value": "Approaching goal",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Approaching goal"
     },
     {
       "name": "inv-tooltip-availability",
-      "value": "Available: %ct",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Available: %ct"
     },
     {
       "name": "stat-health",
-      "value": "Health: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Health: %s"
     },
     {
       "name": "stat-shield",
-      "value": "Shield: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield: %s"
     },
     {
       "name": "stat-shieldRate",
-      "value": "Shield Charge Rate (hp/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield Charge Rate (hp/s): %s"
     },
     {
       "name": "stat-shieldDelay",
-      "value": "Shield Charge Delay (ms): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield Charge Delay (ms): %s"
     },
     {
       "name": "stat-mass",
-      "value": "Mass (kg): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mass (kg): %s"
     },
     {
       "name": "stat-cpu",
-      "value": "Power Usage: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Power Usage: %s"
     },
     {
       "name": "stat-price",
-      "value": "Price: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Price: %s"
     },
     {
       "name": "stat-prem-price",
-      "value": "Premium Price: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Premium Price: %s"
     },
     {
       "name": "stat-thrust",
-      "value": "Thrust: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thrust: %s"
     },
     {
       "name": "stat-rots",
-      "value": "Rotation (deg/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rotation (deg/s): %s"
     },
     {
       "name": "stat-lift",
-      "value": "Lift (kg): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Lift (kg): %s"
     },
     {
       "name": "stat-minlift",
-      "value": "Min Lift (kg): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Min Lift (kg): %s"
     },
     {
       "name": "stat-liftctrl",
-      "value": "Lift Control Rate (kg/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Lift Control Rate (kg/s): %s"
     },
     {
       "name": "stat-damage",
-      "value": "Damage: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Damage: %s"
     },
     {
       "name": "stat-secondaryammovalue",
-      "value": "Secondary Stock Value: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Secondary Stock Value: %s"
     },
     {
       "name": "auxstat-knockback",
-      "value": "Knockback (kn): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Knockback (kn): %s"
     },
     {
       "name": "auxstat-cooldown",
-      "value": "Cooldown (s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cooldown (s): %s"
     },
     {
       "name": "auxstat-activationcooldown",
-      "value": "Activation Cooldown (s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Activation Cooldown (s): %s"
     },
     {
       "name": "auxstat-range",
-      "value": "Range (m): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Range (m): %s"
     },
     {
       "name": "auxstat-dashspeed",
-      "value": "Dash Speed (m/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Dash Speed (m/s): %s"
     },
     {
       "name": "auxstat-dashduration",
-      "value": "Dash Duration (s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Dash Duration (s): %s"
     },
     {
       "name": "auxstat-buffduration",
-      "value": "Buff Duration (s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Buff Duration (s): %s"
     },
     {
       "name": "auxstat-chaffcloudduration",
-      "value": "Cloud Duration (s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cloud Duration (s): %s"
     },
     {
       "name": "auxstat-capacity",
-      "value": "Capacity: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Capacity: %s"
     },
     {
       "name": "auxstat-rechargerate",
-      "value": "Recharge Rate (/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Recharge Rate (/s): %s"
     },
     {
       "name": "auxstat-rechargedelay",
-      "value": "Recharge Delay (s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Recharge Delay (s): %s"
     },
     {
       "name": "auxstat-passivedrain",
-      "value": "Passive Drain (/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Passive Drain (/s): %s"
     },
     {
       "name": "auxstat-activedrain",
-      "value": "Active Drain (/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Active Drain (/s): %s"
     },
     {
       "name": "auxstat-activationcost",
-      "value": "Activation Cost: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Activation Cost: %s"
     },
     {
       "name": "auxstat-thrustmultiplier",
-      "value": "Thrust Multiplier: x%s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thrust Multiplier: x%s"
     },
     {
       "name": "auxstat-restockrate",
-      "value": "Secondary Restock Rate (/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Secondary Restock Rate (/s): %s"
     },
     {
       "name": "auxstat-dampen",
-      "value": "Rotation Multiplier (/s): x%s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rotation Multiplier (/s): x%s"
     },
     {
       "name": "auxstat-nominalcount",
-      "value": "Nominal Cap: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nominal Cap: %s"
     },
     {
       "name": "auxstat-wingcontrol",
-      "value": "Max Control Force (kN): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Max Control Force (kN): %s"
     },
     {
       "name": "auxstat-winglift",
-      "value": "Max Lift Force (kN): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Max Lift Force (kN): %s"
     },
     {
       "name": "auxstat-wingstability",
-      "value": "Max Stabilizing Force (kN): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Max Stabilizing Force (kN): %s"
     },
     {
       "name": "auxstat-wingdrag",
-      "value": "Max Drag Force (kN): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Max Drag Force (kN): %s"
     },
     {
       "name": "auxstat-vectorthrust",
-      "value": "Max Vectoring Foce (kN): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Max Vectoring Foce (kN): %s"
     },
     {
       "name": "auxstat-falloffstart",
-      "value": "Optimal Range (m): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Optimal Range (m): %s"
     },
     {
       "name": "auxstat-falloffend",
-      "value": "Max Range (m): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Max Range (m): %s"
     },
     {
       "name": "auxstat-aoeradius",
-      "value": "AoE Radius (m): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "AoE Radius (m): %s"
     },
     {
       "name": "auxstat-aoefalloff",
-      "value": "AoE Falloff: x%s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "AoE Falloff: x%s"
     },
     {
       "name": "auxstat-fluxrestockrate",
-      "value": "Secondary Restock Rate (/s): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Secondary Restock Rate (/s): %s"
     },
     {
       "name": "auxstat-secondarymagazinecap",
-      "value": "Active Magazine Cap: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Active Magazine Cap: %s"
     },
     {
       "name": "auxstat-secondaryreserveammo",
-      "value": "Reserve Ammo: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Reserve Ammo: %s"
     },
     {
       "name": "auxstat-secondaryreloaddelay",
-      "value": "Reload Delay: %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Reload Delay: %s"
     },
     {
       "name": "auxstat-secondarycharges",
-      "value": "Charges (per Ammo): %s",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Charges (per Ammo): %s"
     },
     {
       "name": "garagebackground-0",
-      "value": "Disabled",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Disabled"
     },
     {
       "name": "garagebackground-1",
-      "value": "Space Black",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Space Black"
     },
     {
       "name": "garagebackground-2",
-      "value": "Space Red",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Space Red"
     },
     {
       "name": "garagebackground-3",
-      "value": "Space Blue",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Space Blue"
     },
     {
       "name": "garagebackground-4",
-      "value": "Space Green",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Space Green"
     },
     {
       "name": "garagebackground-5",
-      "value": "Space Purple",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Space Purple"
     },
     {
       "name": "garagebackground-6",
-      "value": "Space Dreamy",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Space Dreamy"
     },
     {
       "name": "garagebackground-7",
-      "value": "Sky",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Sky"
     },
     {
       "name": "garagebackground-8",
-      "value": "Alpha Prospect",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Alpha Prospect"
     },
     {
       "name": "garagebackground-9",
-      "value": "Deimos Nexus",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Deimos Nexus"
     },
     {
       "name": "garagebackground-10",
-      "value": "Ganges Mensa",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ganges Mensa"
     },
     {
       "name": "garagebackground-11",
-      "value": "Icarus North",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Icarus North"
     },
     {
       "name": "garagebackground-12",
-      "value": "Blueprints",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Blueprints"
     },
     {
       "name": "garagebackground-13",
-      "value": "Redprints",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Redprints"
     },
     {
       "name": "garagebackground-14",
-      "value": "Greenprints",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Greenprints"
     },
     {
       "name": "garagebackground-15",
-      "value": "Yellowprints",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Yellowprints"
     },
     {
       "name": "garagebackground-16",
-      "value": "Studio Lights",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Studio Lights"
     },
     {
       "name": "garagebackground-17",
-      "value": "The Sun! The Sun!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The Sun! The Sun!"
     },
     {
       "name": "garagebackground-18",
-      "value": "Cap'n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cap'n"
     },
     {
       "name": "cosmetic-skin_gun_camo-name",
-      "value": "DDPAT Primary Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Primary Skin"
     },
     {
       "name": "cosmetic-skin_gun_camo-desc",
-      "value": "DDPAT Camo skin.\n\nFor primary weapons.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Camo skin.\n\nFor primary weapons."
     },
     {
       "name": "cosmetic-weaponskinplaceholder2-name",
-      "value": "ELC Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "ELC Skin"
     },
     {
       "name": "cosmetic-weaponskinplaceholder2-desc",
-      "value": "DDPAT Camo skin, paintable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Camo skin, paintable."
     },
     {
       "name": "cosmetic-weaponskinplaceholder3-name",
-      "value": "Nova Bomber",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova Bomber"
     },
     {
       "name": "cosmetic-weaponskinplaceholder3-desc",
-      "value": "Nova bomber themed skin, paintable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova bomber themed skin, paintable."
     },
     {
       "name": "cosmetic-gun_skin_nova_bomber-name",
-      "value": "Gauss DDPAT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gauss DDPAT"
     },
     {
       "name": "cosmetic-gun_skin_nova_bomber-desc",
-      "value": "DDPAT Camo skin, paintable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Camo skin, paintable."
     },
     {
       "name": "cosmetic-weaponskinplaceholder5-name",
-      "value": "Weaver DDPAT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Weaver DDPAT"
     },
     {
       "name": "cosmetic-weaponskinplaceholder5-desc",
-      "value": "DDPAT Camo skin, paintable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Camo skin, paintable."
     },
     {
       "name": "cosmetic-weaponskingoldgauss-name",
-      "value": "Gauss Gold",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gauss Gold"
     },
     {
       "name": "cosmetic-weaponskingoldgauss-desc",
-      "value": "Gold Gauss skin, paintable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gold Gauss skin, paintable."
     },
     {
       "name": "cosmetic-weaponskincarbongauss-name",
-      "value": "Gauss Carbon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gauss Carbon"
     },
     {
       "name": "cosmetic-weaponskincarbongauss-desc",
-      "value": "Carbon Fiber Gauss skin, paintable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Fiber Gauss skin, paintable."
     },
     {
       "name": "cosmetic-skin_gun_primary_supporter-name",
-      "value": "Supporter Primary Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Supporter Primary Skin"
     },
     {
       "name": "cosmetic-skin_gun_primary_supporter-desc",
-      "value": "Show off your support in style.\n\nFor primary weapons.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Show off your support in style.\n\nFor primary weapons."
     },
     {
       "name": "cosmetic-skin_gun_secondary_supporter-name",
-      "value": "Supporter Secondary Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Supporter Secondary Skin"
     },
     {
       "name": "cosmetic-skin_gun_secondary_supporter-desc",
-      "value": "Show off your support in style.\n\nFor primary weapons.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Show off your support in style.\n\nFor primary weapons."
     },
     {
       "name": "cosmetic-skin_mov_wing_fed-name",
-      "value": "FSAF Aero Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "FSAF Aero Skin"
     },
     {
       "name": "cosmetic-skin_mov_wing_fed-desc",
-      "value": "This constitutes a false flag operation.\n\nApplicable to wings and rudders.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "This constitutes a false flag operation.\n\nApplicable to wings and rudders."
     },
     {
       "name": "cosmetic-skin_mov_wing_camo-name",
-      "value": "DDPAT Aero Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Aero Skin"
     },
     {
       "name": "cosmetic-skin_mov_wing_camo-desc",
-      "value": "For hiding aircraft inside pixelated environments.\n\nApplicable to wings and rudders.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "For hiding aircraft inside pixelated environments.\n\nApplicable to wings and rudders."
     },
     {
       "name": "cosmetic-skin_mov_wing_supporter-name",
-      "value": "Supporter Aero Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Supporter Aero Skin"
     },
     {
       "name": "cosmetic-skin_mov_wing_supporter-desc",
-      "value": "Show off your support in style.\n\nApplicable to wings and rudders.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Show off your support in style.\n\nApplicable to wings and rudders."
     },
     {
       "name": "cosmetic-skin_module_supporter-name",
-      "value": "Supporter Module Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Supporter Module Skin"
     },
     {
       "name": "cosmetic-skin_module_supporter-desc",
-      "value": "Show off your support in style.\n\nFor modules.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Show off your support in style.\n\nFor modules."
     },
     {
       "name": "cosmetic-partglowred-name",
-      "value": "Static Red",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Red"
     },
     {
       "name": "cosmetic-partglowred-desc",
-      "value": "Gives an arcshield a red color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a red color."
     },
     {
       "name": "cosmetic-partglowblue-name",
-      "value": "Static Blue",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Blue"
     },
     {
       "name": "cosmetic-partglowblue-desc",
-      "value": "Gives an arcshield a purple-blue color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a purple-blue color."
     },
     {
       "name": "cosmetic-partglowyellow-name",
-      "value": "Static Yellow",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Yellow"
     },
     {
       "name": "cosmetic-partglowyellow-desc",
-      "value": "Gives an arcshield a yellow color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a yellow color."
     },
     {
       "name": "cosmetic-partglowgreen-name",
-      "value": "Static Green",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Green"
     },
     {
       "name": "cosmetic-partglowgreen-desc",
-      "value": "Gives an arcshield a green color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a green color."
     },
     {
       "name": "cosmetic-partglowpurple-name",
-      "value": "Static Purple",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Purple"
     },
     {
       "name": "cosmetic-partglowpurple-desc",
-      "value": "Gives an arcshield a purple color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a purple color."
     },
     {
       "name": "cosmetic-partgloworange-name",
-      "value": "Static Orange",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Orange"
     },
     {
       "name": "cosmetic-partgloworange-desc",
-      "value": "Gives an arcshield a orange color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a orange color."
     },
     {
       "name": "cosmetic-partglowwhite-name",
-      "value": "Static White",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static White"
     },
     {
       "name": "cosmetic-partglowwhite-desc",
-      "value": "Gives an arcshield a white color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a white color."
     },
     {
       "name": "cosmetic-partglowblack-name",
-      "value": "Static Black",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Black"
     },
     {
       "name": "cosmetic-partglowblack-desc",
-      "value": "Gives an arcshield a black color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a black color."
     },
     {
       "name": "cosmetic-partglowmilitary-name",
-      "value": "Static Military",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Military"
     },
     {
       "name": "cosmetic-partglowmilitary-desc",
-      "value": "Gives an arcshield a military green color.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a military green color."
     },
     {
       "name": "cosmetic-partglowbee-name",
-      "value": "Gradient Bee",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gradient Bee"
     },
     {
       "name": "cosmetic-partglowbee-desc",
-      "value": "Gives an arcshield a bee inspired gradient.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a bee inspired gradient."
     },
     {
       "name": "cosmetic-partglowice-name",
-      "value": "Gradient Ice",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gradient Ice"
     },
     {
       "name": "cosmetic-partglowice-desc",
-      "value": "Gives an arcshield an ice inspired gradient.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield an ice inspired gradient."
     },
     {
       "name": "cosmetic-partglowdarkred-name",
-      "value": "Static Dark Red",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Static Dark Red"
     },
     {
       "name": "cosmetic-partglowdarkred-desc",
-      "value": "Gives an arcshield a dark red color. \n\nNothing edgier than a spoon.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a dark red color. \n\nNothing edgier than a spoon."
     },
     {
       "name": "cosmetic-partglowpurpulse-name",
-      "value": "Gradient Pulsor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gradient Pulsor"
     },
     {
       "name": "cosmetic-partglowpurpulse-desc",
-      "value": "Gives an arcshield a purple/black pulsing gradient.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a purple/black pulsing gradient."
     },
     {
       "name": "cosmetic-partglowthunder-name",
-      "value": "Gradient Thunder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gradient Thunder"
     },
     {
       "name": "cosmetic-partglowthunder-desc",
-      "value": "Gives an arcshield a pulsing thunder inspired gradient.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a pulsing thunder inspired gradient."
     },
     {
       "name": "cosmetic-partglowearth-name",
-      "value": "Gradient Earth",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gradient Earth"
     },
     {
       "name": "cosmetic-partglowearth-desc",
-      "value": "Gives an arcshield an earth inspired gradient.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield an earth inspired gradient."
     },
     {
       "name": "cosmetic-partglowrainbow-name",
-      "value": "Gradient Rainbow",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gradient Rainbow"
     },
     {
       "name": "cosmetic-partglowrainbow-desc",
-      "value": "Gives an arcshield the rainbow gradient.\n\nFor the true gamer.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield the rainbow gradient.\n\nFor the true gamer."
     },
     {
       "name": "cosmetic-electroplatepatterncube-name",
-      "value": "Cubes",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cubes"
     },
     {
       "name": "cosmetic-electroplatepatterncube-desc",
-      "value": "Gives an arcshield a cubed pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a cubed pattern."
     },
     {
       "name": "cosmetic-electroplatepatterntri1-name",
-      "value": "Triangles 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Triangles 1"
     },
     {
       "name": "cosmetic-electroplatepatterntri1-desc",
-      "value": "Gives an arcshield a triangled pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a triangled pattern."
     },
     {
       "name": "cosmetic-electroplatepatterntri2-name",
-      "value": "Triangles 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Triangles 2"
     },
     {
       "name": "cosmetic-electroplatepatterntri2-desc",
-      "value": "Gives an arcshield a triangled pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a triangled pattern."
     },
     {
       "name": "cosmetic-electroplatepatterntri3-name",
-      "value": "Triangles 3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Triangles 3"
     },
     {
       "name": "cosmetic-electroplatepatterntri3-desc",
-      "value": "Gives an arcshield a triangled pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a triangled pattern."
     },
     {
       "name": "cosmetic-electroplatepatterncarbon-name",
-      "value": "Carbon Fiber",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Fiber"
     },
     {
       "name": "cosmetic-electroplatepatterncarbon-desc",
-      "value": "Gives an arcshield a carbon fiber pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a carbon fiber pattern."
     },
     {
       "name": "cosmetic-electroplatepatterncamo-name",
-      "value": "Urban DDPAT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Urban DDPAT"
     },
     {
       "name": "cosmetic-electroplatepatterncamo-desc",
-      "value": "Gives an arcshield an urban DDPAT camouflage pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield an urban DDPAT camouflage pattern."
     },
     {
       "name": "cosmetic-electroplatepatternprem1-name",
-      "value": "Low Poly",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Low Poly"
     },
     {
       "name": "cosmetic-electroplatepatternprem1-desc",
-      "value": "Gives an arcshield a low poly pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a low poly pattern."
     },
     {
       "name": "cosmetic-electroplatepatternprem2-name",
-      "value": "Hazard Stripes",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hazard Stripes"
     },
     {
       "name": "cosmetic-electroplatepatternprem2-desc",
-      "value": "Gives an arcshield a hazard stripe pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a hazard stripe pattern."
     },
     {
       "name": "cosmetic-electroplatepatternprem3-name",
-      "value": "Squares",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Squares"
     },
     {
       "name": "cosmetic-electroplatepatternprem3-desc",
-      "value": "Gives an arcshield a squared pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a squared pattern."
     },
     {
       "name": "cosmetic-electroplatepatternclassic-name",
-      "value": "Honeycomb",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Honeycomb"
     },
     {
       "name": "cosmetic-electroplatepatternclassic-desc",
-      "value": "Gives an arcshield a classic alpha honeycomb pattern.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a classic alpha honeycomb pattern."
     },
     {
       "name": "cosmetic-electroplatepatternsupporter-name",
-      "value": "Supporter Shield Pattern",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Supporter Shield Pattern"
     },
     {
       "name": "cosmetic-electroplatepatternsupporter-desc",
-      "value": "Gives an arcshield a formation of isopods.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gives an arcshield a formation of isopods."
     },
     {
       "name": "cosmetic-thrusterexhaustpurple-name",
-      "value": "Purple",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Purple"
     },
     {
       "name": "cosmetic-thrusterexhaustpurple-desc",
-      "value": "Simply purple, not very exciting.\n\nAn alternate exhaust trail for thrusters,",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Simply purple, not very exciting.\n\nAn alternate exhaust trail for thrusters,"
     },
     {
       "name": "cosmetic-thrusterexhaustblue-name",
-      "value": "Cryogenic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cryogenic"
     },
     {
       "name": "cosmetic-thrusterexhaustblue-desc",
-      "value": "Also useful for sleeping!\n\nAn alternate exhaust trail for thrusters,",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Also useful for sleeping!\n\nAn alternate exhaust trail for thrusters,"
     },
     {
       "name": "cosmetic-thrusterexhaustmusic-name",
-      "value": "Music",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Music"
     },
     {
       "name": "cosmetic-thrusterexhaustmusic-desc",
-      "value": "Pretty sound waves, by Blade (he just does the music).\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Pretty sound waves, by Blade (he just does the music).\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustplasma-name",
-      "value": "Nova",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova"
     },
     {
       "name": "cosmetic-thrusterexhaustplasma-desc",
-      "value": "Nova styled thruster exhaust.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova styled thruster exhaust.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustglow-name",
-      "value": "Glow",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Glow"
     },
     {
       "name": "cosmetic-thrusterexhaustglow-desc",
-      "value": "Don't look directly at it.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Don't look directly at it.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustpan-name",
-      "value": "Jacked",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Jacked"
     },
     {
       "name": "cosmetic-thrusterexhaustpan-desc",
-      "value": "Lose the suckers!\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Lose the suckers!\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustgreen-name",
-      "value": "Green",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Green"
     },
     {
       "name": "cosmetic-thrusterexhaustgreen-desc",
-      "value": "You know I'm something of a scientist myself.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "You know I'm something of a scientist myself.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustrings-name",
-      "value": "Gold",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gold"
     },
     {
       "name": "cosmetic-thrusterexhaustrings-desc",
-      "value": "Ooohhh shiny!\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ooohhh shiny!\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustclassic-name",
-      "value": "Classic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Classic"
     },
     {
       "name": "cosmetic-thrusterexhaustclassic-desc",
-      "value": "The Audiovisual Experience.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The Audiovisual Experience.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhausthexglow-name",
-      "value": "Hexglow",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hexglow"
     },
     {
       "name": "cosmetic-thrusterexhausthexglow-desc",
-      "value": "A red glowing hex trail.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A red glowing hex trail.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustwireframe-name",
-      "value": "Wireframe",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wireframe"
     },
     {
       "name": "cosmetic-thrusterexhaustwireframe-desc",
-      "value": "Rotating a cube inside your mind is always free.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rotating a cube inside your mind is always free.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustspiral-name",
-      "value": "Spiral",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Spiral"
     },
     {
       "name": "cosmetic-thrusterexhaustspiral-desc",
-      "value": "Your thrust will be the thrust that pierces the heavens.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Your thrust will be the thrust that pierces the heavens.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustcordium-name",
-      "value": "Cordial",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cordial"
     },
     {
       "name": "cosmetic-thrusterexhaustcordium-desc",
-      "value": "Frequently cited as a factor of several geothermal and geopolitical disasters.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frequently cited as a factor of several geothermal and geopolitical disasters.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustph4-name",
-      "value": "Placeholder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placeholder"
     },
     {
       "name": "cosmetic-thrusterexhaustph4-desc",
-      "value": "Placeholder.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placeholder.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustph5-name",
-      "value": "Placeholder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placeholder"
     },
     {
       "name": "cosmetic-thrusterexhaustph5-desc",
-      "value": "Placeholder.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placeholder.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-thrusterexhaustph6-name",
-      "value": "Placeholder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placeholder"
     },
     {
       "name": "cosmetic-thrusterexhaustph6-desc",
-      "value": "Placeholder.\n\nAn alternate exhaust trail for thrusters.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placeholder.\n\nAn alternate exhaust trail for thrusters."
     },
     {
       "name": "cosmetic-horn_alt_1-name",
-      "value": "Horn Alt SFX 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Horn Alt SFX 1"
     },
     {
       "name": "cosmetic-horn_alt_1-desc",
-      "value": "beep beep 1 (placeholder)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "beep beep 1 (placeholder)"
     },
     {
       "name": "cosmetic-horn_alt_2-name",
-      "value": "Horn Alt SFX 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Horn Alt SFX 2"
     },
     {
       "name": "cosmetic-horn_alt_2-desc",
-      "value": "beep beep 2 (placeholder)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "beep beep 2 (placeholder)"
     },
     {
       "name": "cosmetic-horn_alt_3-name",
-      "value": "Horn Alt SFX 3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Horn Alt SFX 3"
     },
     {
       "name": "cosmetic-horn_alt_3-desc",
-      "value": "beep beep 3 (placeholder)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "beep beep 3 (placeholder)"
     },
     {
       "name": "cosmetic-horn_alt_4-name",
-      "value": "Horn Alt SFX 4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Horn Alt SFX 4"
     },
     {
       "name": "cosmetic-horn_alt_4-desc",
-      "value": "beep beep 4 (placeholder)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "beep beep 4 (placeholder)"
     },
     {
       "name": "cosmetic-electroplatepatternhlwn122-name",
-      "value": "Halloween",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Halloween"
     },
     {
       "name": "cosmetic-electroplatepatternhlwn122-desc",
-      "value": "For the spooky season. \n\nDOOT DOOT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "For the spooky season. \n\nDOOT DOOT"
     },
     {
       "name": "cosmetic-electroplatepatternhlwn222-name",
-      "value": "Halloween",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Halloween"
     },
     {
       "name": "cosmetic-electroplatepatternhlwn222-desc",
-      "value": "For the spooky season. \n\nDOOT DOOT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "For the spooky season. \n\nDOOT DOOT"
     },
     {
       "name": "cosmetic-electroplatepatternxmas122-name",
-      "value": "X-mas",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "X-mas"
     },
     {
       "name": "cosmetic-electroplatepatternxmas122-desc",
-      "value": "Jolly time to destroy your enemy. \n\nBing Bong.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Jolly time to destroy your enemy. \n\nBing Bong."
     },
     {
       "name": "cosmetic-electroplatepatternxmas222-name",
-      "value": "X-mas",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "X-mas"
     },
     {
       "name": "cosmetic-electroplatepatternxmas222-desc",
-      "value": "Jolly time to destroy your enemy. \n\nBing Bong.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Jolly time to destroy your enemy. \n\nBing Bong."
     },
     {
       "name": "inv-cat-blocks",
-      "value": "Normal Chassis Blocks",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Chassis Blocks"
     },
     {
       "name": "inv-cat-heavyblocks",
-      "value": "Heavy Chassis Blocks",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Chassis Blocks"
     },
     {
       "name": "inv-cat-glassblocks",
-      "value": "Light Chassis Blocks",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Light Chassis Blocks"
     },
     {
       "name": "inv-cat-aeroframe",
-      "value": "Airframes",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Airframes"
     },
     {
       "name": "inv-cat-core",
-      "value": "Functionals",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Functionals"
     },
     {
       "name": "inv-cat-viz",
-      "value": "Functional Cosmetics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Functional Cosmetics"
     },
     {
       "name": "inv-cat-electroplates",
-      "value": "Arcshield Plates",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield Plates"
     },
     {
       "name": "inv-cat-module",
-      "value": "Modules",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Modules"
     },
     {
       "name": "inv-cat-movement",
-      "value": "Movement Parts",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Movement Parts"
     },
     {
       "name": "inv-cat-groundmovement",
-      "value": "Ground Movement",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ground Movement"
     },
     {
       "name": "inv-cat-wings",
-      "value": "Wings",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wings"
     },
     {
       "name": "inv-cat-thrusters",
-      "value": "Thrusters",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thrusters"
     },
     {
       "name": "inv-cat-LTA",
-      "value": "LTA Canisters",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "LTA Canisters"
     },
     {
       "name": "inv-cat-wep-pri",
-      "value": "Primary Weapons",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Primary Weapons"
     },
     {
       "name": "inv-cat-wep-sec",
-      "value": "Secondary Weapons",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Secondary Weapons"
     },
     {
       "name": "inv-cat-cosm",
-      "value": "Cosmetics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cosmetics"
     },
     {
       "name": "inv-cat-cosm-wep",
-      "value": "Weapon Skins",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Weapon Skins"
     },
     {
       "name": "inv-cat-cosm-mov",
-      "value": "Movement Skins",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Movement Skins"
     },
     {
       "name": "inv-cat-cosm-thruster",
-      "value": "Thruster Exhausts",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster Exhausts"
     },
     {
       "name": "inv-cat-cosm-pattern",
-      "value": "Shield Patterns",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield Patterns"
     },
     {
       "name": "inv-cat-cosm-glow",
-      "value": "Shield Colors",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield Colors"
     },
     {
       "name": "inv-cat-cosm-stickers",
-      "value": "Stickers",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stickers"
     },
     {
       "name": "inv-cat-cosm-supporter",
-      "value": "Supporter Pack Rewards",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Supporter Pack Rewards"
     },
     {
       "name": "inv-cat-info",
-      "value": "Information",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Information"
     },
     {
       "name": "weapon-category-laser",
-      "value": "Electrolaser Carbine",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Electrolaser Carbine"
     },
     {
       "name": "weapon-category-gauss",
-      "value": "Gauss Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gauss Rifle"
     },
     {
       "name": "weapon-category-plasma",
-      "value": "Nova Cannon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova Cannon"
     },
     {
       "name": "weapon-category-nano",
-      "value": "Flux Weaver",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flux Weaver"
     },
     {
       "name": "weapon-category-rivet",
-      "value": "Rivet Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rivet Rifle"
     },
     {
       "name": "weapon-category-mwave",
-      "value": "Wave Splitter",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wave Splitter"
     },
     {
       "name": "weapon-category-salvo",
-      "value": "Cerberus UMRL",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cerberus UMRL"
     },
     {
       "name": "weapon-category-trace",
-      "value": "Sighthound LGML",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Sighthound LGML"
     },
     {
       "name": "weapon-category-slablauncher",
-      "value": "SOML Turret",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "SOML Turret"
     },
     {
       "name": "weapon-category-missile",
-      "value": "Missile Launcher",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Missile Launcher"
     },
     {
       "name": "weapon-category-mine",
-      "value": "Mine Layer",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mine Layer"
     },
     {
       "name": "weapon-category-tesla",
-      "value": "CAS Cutter",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "CAS Cutter"
     },
     {
       "name": "weapon-category-smoke",
-      "value": "Smokescreen",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smokescreen"
     },
     {
       "name": "weapon-category-minigun",
-      "value": "Autocannon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Autocannon"
     },
     {
       "name": "weapon-category-bomb",
-      "value": "UGB",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "UGB"
     },
     {
       "name": "weapon-category-assaultgauss",
-      "value": "Assault Gauss",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Assault Gauss"
     },
     {
       "name": "weapon-category-tripwire",
-      "value": "Tripwire",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tripwire"
     },
     {
       "name": "weapon-category-fluxlauncher",
-      "value": "Flux Mortar",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flux Mortar"
     },
     {
       "name": "weapon-category-rocketpod",
-      "value": "Scylla RKT Pod",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Scylla RKT Pod"
     },
     {
       "name": "block-alpha_1x2core-name",
-      "value": "Robot Core",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot Core"
     },
     {
       "name": "block-alpha_1x2core-desc",
-      "value": "The controller and power core of a robot. Any blocks disconnected from it are destroyed, and if no functional components remain your bot will be destroyed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The controller and power core of a robot. Any blocks disconnected from it are destroyed, and if no functional components remain your bot will be destroyed."
     },
     {
       "name": "block-alpha_whitecube-name",
-      "value": "Normal Cube",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Cube"
     },
     {
       "name": "block-alpha_whitecube-desc",
-      "value": "Your generic 6-sided chassis block, allowing connectivity and damage flow on all sides.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Your generic 6-sided chassis block, allowing connectivity and damage flow on all sides."
     },
     {
       "name": "block-alpha_whiteinner-name",
-      "value": "Normal Inner",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Inner"
     },
     {
       "name": "block-alpha_whiteinner-desc",
-      "value": "A truncated chassis cube: the same connectivity at lower weight.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A truncated chassis cube: the same connectivity at lower weight."
     },
     {
       "name": "block-alpha_whiteprism-name",
-      "value": "Normal Prism",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Prism"
     },
     {
       "name": "block-alpha_whiteprism-desc",
-      "value": "A prism-shaped chassis piece. Used for aesthetics or for its lower weight.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A prism-shaped chassis piece. Used for aesthetics or for its lower weight."
     },
     {
       "name": "block-alpha_whitetetra-name",
-      "value": "Normal Tetra",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Tetra"
     },
     {
       "name": "block-alpha_whitetetra-desc",
-      "value": "A small lightweight chassis component, often used for routing connectivity and damage flow.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small lightweight chassis component, often used for routing connectivity and damage flow."
     },
     {
       "name": "block-alpha_whitepyramid-name",
-      "value": "Normal Pyramid",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Pyramid"
     },
     {
       "name": "block-alpha_whitepyramid-desc",
-      "value": "A square-bottom variant of the tetra.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A square-bottom variant of the tetra."
     },
     {
       "name": "block-alpha_heavycube-name",
-      "value": "Heavy Cube",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Cube"
     },
     {
       "name": "block-alpha_heavycube-desc",
-      "value": "A heavier variant of the chassis cube.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A heavier variant of the chassis cube."
     },
     {
       "name": "block-alpha_heavyinner-name",
-      "value": "Heavy Inner",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Inner"
     },
     {
       "name": "block-alpha_heavyinner-desc",
-      "value": "A heavier variant of the chassis inner.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A heavier variant of the chassis inner."
     },
     {
       "name": "block-alpha_heavyprism-name",
-      "value": "Heavy Prism",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Prism"
     },
     {
       "name": "block-alpha_heavyprism-desc",
-      "value": "A heavier variant of the chassis prism.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A heavier variant of the chassis prism."
     },
     {
       "name": "block-alpha_heavytetra-name",
-      "value": "Heavy Tetra",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Tetra"
     },
     {
       "name": "block-alpha_heavytetra-desc",
-      "value": "A heavier variant of the chassis tetra.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A heavier variant of the chassis tetra."
     },
     {
       "name": "block-alpha_heavypyramid-name",
-      "value": "Heavy Pyramid",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Pyramid"
     },
     {
       "name": "block-alpha_heavypyramid-desc",
-      "value": "A heavier variant of the chassis pyramid.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A heavier variant of the chassis pyramid."
     },
     {
       "name": "block-alpha_glasscube-name",
-      "value": "Glass Cube",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Glass Cube"
     },
     {
       "name": "block-alpha_glasscube-desc",
-      "value": "A lighter and more reflective variant of the chassis cube.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis cube."
     },
     {
       "name": "block-alpha_glassinner-name",
-      "value": "Glass Inner",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Glass Inner"
     },
     {
       "name": "block-alpha_glassinner-desc",
-      "value": "A lighter and more reflective variant of the chassis inner.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis inner."
     },
     {
       "name": "block-alpha_glassprism-name",
-      "value": "Glass Prism",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Glass Prism"
     },
     {
       "name": "block-alpha_glassprism-desc",
-      "value": "A lighter and more reflective variant of the chassis prism.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis prism."
     },
     {
       "name": "block-alpha_glasstetra-name",
-      "value": "Glass Tetra",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Glass Tetra"
     },
     {
       "name": "block-alpha_glasstetra-desc",
-      "value": "A lighter and more reflective variant of the chassis tetra.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis tetra."
     },
     {
       "name": "block-alpha_glasspyramid-name",
-      "value": "Glass Pyramid",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Glass Pyramid"
     },
     {
       "name": "block-alpha_glasspyramid-desc",
-      "value": "A lighter and more reflective variant of the chassis pyramid.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis pyramid."
     },
     {
       "name": "block-alpha_smoothcube-name",
-      "value": "Smooth Cube",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smooth Cube"
     },
     {
       "name": "block-alpha_smoothcube-desc",
-      "value": "A smoother variant of the chassis cube.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A smoother variant of the chassis cube."
     },
     {
       "name": "block-alpha_smoothinner-name",
-      "value": "Smooth Inner",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smooth Inner"
     },
     {
       "name": "block-alpha_smoothinner-desc",
-      "value": "A smoother variant of the chassis inner.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A smoother variant of the chassis inner."
     },
     {
       "name": "block-alpha_smoothprism-name",
-      "value": "Smooth Prism",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smooth Prism"
     },
     {
       "name": "block-alpha_smoothprism-desc",
-      "value": "A smoother variant of the chassis prism.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A smoother variant of the chassis prism."
     },
     {
       "name": "block-alpha_smoothtetra-name",
-      "value": "Smooth Tetra",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smooth Tetra"
     },
     {
       "name": "block-alpha_smoothtetra-desc",
-      "value": "A smoother variant of the chassis tetra.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A smoother variant of the chassis tetra."
     },
     {
       "name": "block-alpha_smoothpyramid-name",
-      "value": "Smooth Pyramid",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smooth Pyramid"
     },
     {
       "name": "block-alpha_smoothpyramid-desc",
-      "value": "A smoother variant of the chassis pyramid.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A smoother variant of the chassis pyramid."
     },
     {
       "name": "block-alpha_carboncube-name",
-      "value": "Carbon Cube",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Cube"
     },
     {
       "name": "block-alpha_carboncube-desc",
-      "value": "A lighter and more reflective variant of the chassis cube.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis cube."
     },
     {
       "name": "block-alpha_carboninner-name",
-      "value": "Carbon Inner",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Inner"
     },
     {
       "name": "block-alpha_carboninner-desc",
-      "value": "A lighter and more reflective variant of the chassis inner.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis inner."
     },
     {
       "name": "block-alpha_carbonprism-name",
-      "value": "Carbon Prism",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Prism"
     },
     {
       "name": "block-alpha_carbonprism-desc",
-      "value": "A lighter and more reflective variant of the chassis prism.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis prism."
     },
     {
       "name": "block-alpha_carbontetra-name",
-      "value": "Carbon Tetra",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Tetra"
     },
     {
       "name": "block-alpha_carbontetra-desc",
-      "value": "A lighter and more reflective variant of the chassis tetra.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis tetra."
     },
     {
       "name": "block-alpha_carbonpyramid-name",
-      "value": "Carbon Pyramid",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Carbon Pyramid"
     },
     {
       "name": "block-alpha_carbonpyramid-desc",
-      "value": "A lighter and more reflective variant of the chassis pyramid.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lighter and more reflective variant of the chassis pyramid."
     },
     {
       "name": "block-alpha_airframe_straight3-name",
-      "value": "Frame 1x3-S",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x3-S"
     },
     {
       "name": "block-alpha_airframe_straight3-desc",
-      "value": "A lightweight rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_straight3_flat-name",
-      "value": "Frame 1x3-S-F",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x3-S-F"
     },
     {
       "name": "block-alpha_airframe_straight3_flat-desc",
-      "value": "A lightweight flat rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight flat rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_straight4-name",
-      "value": "Frame 1x4-S",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x4-S"
     },
     {
       "name": "block-alpha_airframe_straight4-desc",
-      "value": "A lightweight rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_straight5-name",
-      "value": "Frame 1x5-S",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x5-S"
     },
     {
       "name": "block-alpha_airframe_straight5-desc",
-      "value": "A lightweight rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_straight5_flat-name",
-      "value": "Frame 1x5-S-F",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x5-S-F"
     },
     {
       "name": "block-alpha_airframe_straight5_flat-desc",
-      "value": "A lightweight flat rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight flat rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_straight6-name",
-      "value": "Frame 1x6-S",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x6-S"
     },
     {
       "name": "block-alpha_airframe_straight6-desc",
-      "value": "A lightweight rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_angled3-name",
-      "value": "Frame 1x3-A",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x3-A"
     },
     {
       "name": "block-alpha_airframe_angled3-desc",
-      "value": "An angled lightweight rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An angled lightweight rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_angled5-name",
-      "value": "Frame 1x5-A",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x5-A"
     },
     {
       "name": "block-alpha_airframe_angled5-desc",
-      "value": "An angled lightweight rod featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An angled lightweight rod featuring connections on both ends."
     },
     {
       "name": "block-alpha_airframe_tjunction3-name",
-      "value": "Frame 1x3-T",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frame 1x3-T"
     },
     {
       "name": "block-alpha_airframe_tjunction3-desc",
-      "value": "A lightweight split rod featuring connections on each end.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A lightweight split rod featuring connections on each end."
     },
     {
       "name": "block-alpha_thruster_t1-name",
-      "value": "Thruster M1-A",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M1-A"
     },
     {
       "name": "block-alpha_thruster_t1-desc",
-      "value": "A small and simple thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small and simple thruster that can apply force in the placed direction."
     },
     {
       "name": "block-alpha_topmount_thruster-name",
-      "value": "Thruster M1-B",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M1-B"
     },
     {
       "name": "block-alpha_topmount_thruster-desc",
-      "value": "A small and simple thruster, attached directly to a robot.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small and simple thruster, attached directly to a robot."
     },
     {
       "name": "block-alpha_thruster_t5-name",
-      "value": "Thruster M2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M2"
     },
     {
       "name": "block-alpha_thruster_t5-desc",
-      "value": "A medium sized thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A medium sized thruster that can apply force in the placed direction."
     },
     {
       "name": "block-alpha_thruster_t9-name",
-      "value": "Thruster M3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M3"
     },
     {
       "name": "block-alpha_thruster_t9-desc",
-      "value": "A large and powerful thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A large and powerful thruster that can apply force in the placed direction."
     },
     {
       "name": "block-mov_turbofan_thruster-name",
-      "value": "Turbofan Engine",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Turbofan Engine"
     },
     {
       "name": "block-mov_turbofan_thruster-desc",
-      "value": "Test part.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Test part."
     },
     {
       "name": "block-mov_thruster_small-name",
-      "value": "Thruster M1-A",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M1-A"
     },
     {
       "name": "block-mov_thruster_small-desc",
-      "value": "A small and simple thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small and simple thruster that can apply force in the placed direction."
     },
     {
       "name": "block-mov_thruster_small_topmount-name",
-      "value": "Thruster M1-B",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M1-B"
     },
     {
       "name": "block-mov_thruster_small_topmount-desc",
-      "value": "A small and simple thruster, attached directly to a robot.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small and simple thruster, attached directly to a robot."
     },
     {
       "name": "block-mov_thruster_medium-name",
-      "value": "Thruster M2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M2"
     },
     {
       "name": "block-mov_thruster_medium-desc",
-      "value": "A medium sized thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A medium sized thruster that can apply force in the placed direction."
     },
     {
       "name": "block-mov_thruster_medium_flat-name",
-      "value": "Thruster M2-C",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M2-C"
     },
     {
       "name": "block-mov_thruster_medium_flat-desc",
-      "value": "A compact medium sized thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A compact medium sized thruster that can apply force in the placed direction."
     },
     {
       "name": "block-mov_thruster_large-name",
-      "value": "Thruster M3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster M3"
     },
     {
       "name": "block-mov_thruster_large-desc",
-      "value": "A large and powerful thruster that can apply force in the placed direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A large and powerful thruster that can apply force in the placed direction."
     },
     {
       "name": "block-alpha_wheel_t9-name",
-      "value": "Steering Wheel",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Steering Wheel"
     },
     {
       "name": "block-alpha_wheel_t9-desc",
-      "value": "A wheel. Does wheel things.\nCan steer.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A wheel. Does wheel things.\nCan steer."
     },
     {
       "name": "block-alpha_nonsteering_wheel-name",
-      "value": "Non-steering Wheel",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Non-steering Wheel"
     },
     {
       "name": "block-alpha_nonsteering_wheel-desc",
-      "value": "A wheel. Does wheel things.\nDoes not steer.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A wheel. Does wheel things.\nDoes not steer."
     },
     {
       "name": "block-alpha_hoverblade_t9-name",
-      "value": "Hoverblade",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hoverblade"
     },
     {
       "name": "block-alpha_hoverblade_t9-desc",
-      "value": "A powerful fan providing movement within a moderate distance from the ground.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A powerful fan providing movement within a moderate distance from the ground."
     },
     {
       "name": "block-alpha_ski-name",
-      "value": "Ski",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ski"
     },
     {
       "name": "block-alpha_ski-desc",
-      "value": "An unpowered, uncontrolled, low-friction ski.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An unpowered, uncontrolled, low-friction ski."
     },
     {
       "name": "block-alpha_repulsor_pad-name",
-      "value": "A-GRV Repulsion Pad",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A-GRV Repulsion Pad"
     },
     {
       "name": "block-alpha_repulsor_pad-desc",
-      "value": "A high-tech repulsion pad, allowing frictionless travel over terrain in all directions.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech repulsion pad, allowing frictionless travel over terrain in all directions."
     },
     {
       "name": "block-alpha_tank_track_left-name",
-      "value": "Tank Track [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tank Track [L]"
     },
     {
       "name": "block-alpha_tank_track_left-desc",
-      "value": "A durable continous track with multiple drive gears.\n\nHold 'down' to enter high gear, gaining speed but sacrificing turning.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A durable continous track with multiple drive gears.\n\nHold 'down' to enter high gear, gaining speed but sacrificing turning."
     },
     {
       "name": "block-alpha_tank_track_right-name",
-      "value": "Tank Track [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tank Track [R]"
     },
     {
       "name": "block-alpha_tank_track_right-desc",
-      "value": "A durable continous track with multiple drive gears.\n\nHold 'down' to enter high gear, gaining speed but sacrificing turning.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A durable continous track with multiple drive gears.\n\nHold 'down' to enter high gear, gaining speed but sacrificing turning."
     },
     {
       "name": "block-alpha_tank_track_central-name",
-      "value": "Tank Track [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tank Track [M]"
     },
     {
       "name": "block-alpha_tank_track_central-desc",
-      "value": "YOU'RE NOT SUPPOSED TO BE HERE.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "YOU'RE NOT SUPPOSED TO BE HERE."
     },
     {
       "name": "block-mov_leg_small-name",
-      "value": "Light Insect Leg",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Light Insect Leg"
     },
     {
       "name": "block-mov_leg_small-desc",
-      "value": "An agile leg mimicing Earth insects, allowing robots to stably walk on walls and beneath overhangs.\n\nPress XXX to jump. Hold XXX to crouch, charging a boosted jump. Continue holding XXX after jumping to skate after landing.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An agile leg mimicing Earth insects, allowing robots to stably walk on walls and beneath overhangs.\n\nPress XXX to jump. Hold XXX to crouch, charging a boosted jump. Continue holding XXX after jumping to skate after landing."
     },
     {
       "name": "block-mov_leg_medium-name",
-      "value": "Medium Insect Leg",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Medium Insect Leg"
     },
     {
       "name": "block-mov_leg_medium-desc",
-      "value": "A durable leg mimicing Earth insects, allowing robots to stably walk on walls and beneath overhangs.\n\nPress XXX to jump. Hold XXX to crouch, charging a boosted jump. Continue holding XXX after jumping to skate after landing.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A durable leg mimicing Earth insects, allowing robots to stably walk on walls and beneath overhangs.\n\nPress XXX to jump. Hold XXX to crouch, charging a boosted jump. Continue holding XXX after jumping to skate after landing."
     },
     {
       "name": "block-mov_leg_large-name",
-      "value": "Heavy Insect Leg",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Insect Leg"
     },
     {
       "name": "block-mov_leg_large-desc",
-      "value": "A tanky leg mimicing Earth insects, allowing robots to walk on stably walls and beneath overhangs.\n\nPress XXX to jump. Hold XXX to crouch, charging a boosted jump. <b>Unlike its lighter counterparts, Heavy legs are incapable of skating.</b>",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A tanky leg mimicing Earth insects, allowing robots to walk on stably walls and beneath overhangs.\n\nPress XXX to jump. Hold XXX to crouch, charging a boosted jump. <b>Unlike its lighter counterparts, Heavy legs are incapable of skating.</b>"
     },
     {
       "name": "block-mov_wing_flat-name",
-      "value": "Flat Wing",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flat Wing"
     },
     {
       "name": "block-mov_wing_flat-desc",
-      "value": "Simple wings with good low-speed control and modest lift. \n\nProne to diminished control from overspeed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Simple wings with good low-speed control and modest lift. \n\nProne to diminished control from overspeed."
     },
     {
       "name": "block-mov_wing_swept-name",
-      "value": "Swept Wing",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Swept Wing"
     },
     {
       "name": "block-mov_wing_swept-desc",
-      "value": "Stable, high lift wings with moderate drag.\nHarder to stall.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stable, high lift wings with moderate drag.\nHarder to stall."
     },
     {
       "name": "block-mov_wing_delta-name",
-      "value": "Delta Wing",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Delta Wing"
     },
     {
       "name": "block-mov_wing_delta-desc",
-      "value": "Unstable wings with great high speed performance and control, but prone to stalls. \n\nLift performance is reliant on high speeds.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unstable wings with great high speed performance and control, but prone to stalls. \n\nLift performance is reliant on high speeds."
     },
     {
       "name": "block-mov_rud_flat-name",
-      "value": "Flat Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flat Rudder"
     },
     {
       "name": "block-mov_rud_flat-desc",
-      "value": "Control surfaces with good stabilization properties, but low lift.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Control surfaces with good stabilization properties, but low lift."
     },
     {
       "name": "block-mov_rud_swept-name",
-      "value": "Swept Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Swept Rudder"
     },
     {
       "name": "block-mov_rud_swept-desc",
-      "value": "Control surfaces with good stabilization properties, but low lift.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Control surfaces with good stabilization properties, but low lift."
     },
     {
       "name": "block-mov_rud_delta-name",
-      "value": "Delta Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Delta Rudder"
     },
     {
       "name": "block-mov_rud_delta-desc",
-      "value": "Control surfaces with good stabilization properties, but low lift.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Control surfaces with good stabilization properties, but low lift."
     },
     {
       "name": "block-alpha_wing_swept_l-name",
-      "value": "Swept Wing [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Swept Wing [L]"
     },
     {
       "name": "block-alpha_wing_swept_l-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_wing_swept_r-name",
-      "value": "Swept Wing [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Swept Wing [R]"
     },
     {
       "name": "block-alpha_wing_swept_r-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_wing_flat_l-name",
-      "value": "Flat Wing [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flat Wing [L]"
     },
     {
       "name": "block-alpha_wing_flat_l-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_wing_flat_r-name",
-      "value": "Flat Wing [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flat Wing [R]"
     },
     {
       "name": "block-alpha_wing_flat_r-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_rudder-name",
-      "value": "Normal Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Rudder"
     },
     {
       "name": "block-alpha_rudder-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_large_rudder-name",
-      "value": "Large Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Rudder"
     },
     {
       "name": "block-alpha_large_rudder-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_rudder_i-name",
-      "value": "Inactive Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Inactive Rudder"
     },
     {
       "name": "block-alpha_rudder_i-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-alpha_large_rudder_i-name",
-      "value": "Large Inactive Rudder",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Inactive Rudder"
     },
     {
       "name": "block-alpha_large_rudder_i-desc",
-      "value": "A relic of a past time. Probably shouldn't be here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A relic of a past time. Probably shouldn't be here."
     },
     {
       "name": "block-mov_copter_large-name",
-      "value": "Large Rotor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Rotor"
     },
     {
       "name": "block-mov_copter_large-desc",
-      "value": "An unfinished, untested, unconfirmed part.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An unfinished, untested, unconfirmed part."
     },
     {
       "name": "block-mov_copter_small-name",
-      "value": "Small Rotor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Rotor"
     },
     {
       "name": "block-mov_copter_small-desc",
-      "value": "An unfinished, untested, unconfirmed part.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An unfinished, untested, unconfirmed part."
     },
     {
       "name": "block-mov_copter_tail-name",
-      "value": "Encased Rotor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Encased Rotor"
     },
     {
       "name": "block-mov_copter_tail-desc",
-      "value": "An unfinished, untested, unconfirmed part.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An unfinished, untested, unconfirmed part."
     },
     {
       "name": "block-alpha_gyroscope-name",
-      "value": "Gyroscope",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gyroscope"
     },
     {
       "name": "block-alpha_gyroscope-desc",
-      "value": "On activation, helps counteract bot rotation.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, helps counteract bot rotation."
     },
     {
       "name": "block-alpha_radar-name",
-      "value": "Radar",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Radar"
     },
     {
       "name": "block-alpha_radar-desc",
-      "value": "Reveals nearby enemies.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Reveals nearby enemies."
     },
     {
       "name": "block-alpha_radar_jammer-name",
-      "value": "Radar Jammer",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Radar Jammer"
     },
     {
       "name": "block-alpha_radar_jammer-desc",
-      "value": "Counteracts the effects of enemy radar for your bot.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Counteracts the effects of enemy radar for your bot."
     },
     {
       "name": "block-alpha_lasergun_t9-name",
-      "value": "Electrolaser Carbine",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Electrolaser Carbine"
     },
     {
       "name": "block-alpha_lasergun_t9-desc",
-      "value": "A simple fully automatic gun that fires high-energy beams.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A simple fully automatic gun that fires high-energy beams."
     },
     {
       "name": "block-alpha_railgun-name",
-      "value": "Gauss Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gauss Rifle"
     },
     {
       "name": "block-alpha_railgun-desc",
-      "value": "A long-distance, high velocity sniper cannon with a magazine.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A long-distance, high velocity sniper cannon with a magazine."
     },
     {
       "name": "block-alpha_plasmacannon-name",
-      "value": "Nova Cannon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova Cannon"
     },
     {
       "name": "block-alpha_plasmacannon-desc",
-      "value": "Fires a volley of unstable energy payloads.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fires a volley of unstable energy payloads."
     },
     {
       "name": "block-alpha_nanoassembler-name",
-      "value": "Flux Weaver",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flux Weaver"
     },
     {
       "name": "block-alpha_nanoassembler-desc",
-      "value": "Continuous beam weapon that repairs allied bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Continuous beam weapon that repairs allied bots."
     },
     {
       "name": "block-alpha_rivetrifle-name",
-      "value": "Rivet Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rivet Rifle"
     },
     {
       "name": "block-alpha_rivetrifle-desc",
-      "value": "Power tool turned weapon that fires superheated rivets from a magazine.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Power tool turned weapon that fires superheated rivets from a magazine."
     },
     {
       "name": "block-alpha_macrowave-name",
-      "value": "Wave Splitter",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wave Splitter"
     },
     {
       "name": "block-alpha_macrowave-desc",
-      "value": "YOU'RE NOT SUPPOSED TO BE HERE.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "YOU'RE NOT SUPPOSED TO BE HERE."
     },
     {
       "name": "block-alpha_missile_salvo-name",
-      "value": "Cerberus UMRL",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cerberus UMRL"
     },
     {
       "name": "block-alpha_missile_salvo-desc",
-      "value": "Fires a manually-loaded volley of unguided rockets.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fires a manually-loaded volley of unguided rockets."
     },
     {
       "name": "block-alpha_trace_missile-name",
-      "value": "Sighthound LGML",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Sighthound LGML"
     },
     {
       "name": "block-alpha_trace_missile-desc",
-      "value": "Fires an automatic stream of laser-guided missiles.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fires an automatic stream of laser-guided missiles."
     },
     {
       "name": "block-alpha_slab_launcher-name",
-      "value": "SOML Turret",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "SOML Turret"
     },
     {
       "name": "block-alpha_slab_launcher-desc",
-      "value": "Heavy turret that launches large slabs of matter.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy turret that launches large slabs of matter."
     },
     {
       "name": "block-alpha_assault_railgun-name",
-      "value": "Assault Gauss Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Assault Gauss Rifle"
     },
     {
       "name": "block-alpha_assault_railgun-desc",
-      "value": "A shorter range, burst-fired gauss rifle. \n\nUntested.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A shorter range, burst-fired gauss rifle. \n\nUntested."
     },
     {
       "name": "block-alpha_flux_launcher-name",
-      "value": "Flux Mortar",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flux Mortar"
     },
     {
       "name": "block-alpha_flux_launcher-desc",
-      "value": "Fires explosive shells filled with Flux nanomachines. \n\n Heals allies, damages enemies.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fires explosive shells filled with Flux nanomachines. \n\n Heals allies, damages enemies."
     },
     {
       "name": "block-alpha_sec_energyblade-name",
-      "value": "CAS Cutter",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "CAS Cutter"
     },
     {
       "name": "block-alpha_sec_energyblade-desc",
-      "value": "WARNING: Legacy Content, may be unstable.\n\nContained Arc Saw that cuts into enemy bots as a melee attack.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "WARNING: Legacy Content, may be unstable.\n\nContained Arc Saw that cuts into enemy bots as a melee attack."
     },
     {
       "name": "block-alpha_sec_minelayer-name",
-      "value": "Minelayer",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Minelayer"
     },
     {
       "name": "block-alpha_sec_minelayer-desc",
-      "value": "Drops a mine onto the ground which, after activating, will detonate when other bots approach.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Drops a mine onto the ground which, after activating, will detonate when other bots approach."
     },
     {
       "name": "block-alpha_sec_missilelauncher-name",
-      "value": "Missile Launcher",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Missile Launcher"
     },
     {
       "name": "block-alpha_sec_missilelauncher-desc",
-      "value": "Fires a heat-seeking missile.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fires a heat-seeking missile."
     },
     {
       "name": "block-alpha_sec_shieldprojector-name",
-      "value": "Shield Generator",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield Generator"
     },
     {
       "name": "block-alpha_sec_shieldprojector-desc",
-      "value": "Projects an energy shield to block incoming projectiles.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Projects an energy shield to block incoming projectiles."
     },
     {
       "name": "block-alpha_sec_smokescreen-name",
-      "value": "Smoke Launcher",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smoke Launcher"
     },
     {
       "name": "block-alpha_sec_smokescreen-desc",
-      "value": "Launches a canister that emits a cloud of smoke where it lands.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Launches a canister that emits a cloud of smoke where it lands."
     },
     {
       "name": "block-alpha_sec_minigun-name",
-      "value": "Autocannon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Autocannon"
     },
     {
       "name": "block-alpha_sec_minigun-desc",
-      "value": "A devastating fully automatic cannon with limited mount rotation and an internal magazine.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A devastating fully automatic cannon with limited mount rotation and an internal magazine."
     },
     {
       "name": "block-alpha_sec_bombbay-name",
-      "value": "Bomb Bay (Standard)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Bomb Bay (Standard)"
     },
     {
       "name": "block-alpha_sec_bombbay-desc",
-      "value": "Drops a bomb that inherits bot velocity, exploding on contact once armed.\n\n Deals self-damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Drops a bomb that inherits bot velocity, exploding on contact once armed.\n\n Deals self-damage."
     },
     {
       "name": "block-alpha_sec_tripwire-name",
-      "value": "Tripwire",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tripwire"
     },
     {
       "name": "block-alpha_sec_tripwire-desc",
-      "value": "It wires trips.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "It wires trips."
     },
     {
       "name": "block-alpha_sec_rocketpod-name",
-      "value": "Scylla RKT Pod",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Scylla RKT Pod"
     },
     {
       "name": "block-alpha_sec_rocketpod-desc",
-      "value": "A cluster of stabilized unguided rockets, dealing high explosive damage over moderate range.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A cluster of stabilized unguided rockets, dealing high explosive damage over moderate range."
     },
     {
       "name": "block-electroplate_a_l-name",
-      "value": "Arcshield A.L",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield A.L"
     },
     {
       "name": "block-electroplate_a_l-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-electroplate_a_r-name",
-      "value": "Arcshield A.R",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield A.R"
     },
     {
       "name": "block-electroplate_a_r-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-electroplate_b_l-name",
-      "value": "Arcshield B.L",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield B.L"
     },
     {
       "name": "block-electroplate_b_l-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-electroplate_b_r-name",
-      "value": "Arcshield B.R",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield B.R"
     },
     {
       "name": "block-electroplate_b_r-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-electroplate_c-name",
-      "value": "Arcshield C",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield C"
     },
     {
       "name": "block-electroplate_c-desc",
-      "value": "A high-tech energy shield which recharges after taking damage. \n Decomissioned",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage. \n Decomissioned"
     },
     {
       "name": "block-chassis_shield_1-name",
-      "value": "Arcshield M1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M1"
     },
     {
       "name": "block-chassis_shield_1-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_2-name",
-      "value": "Arcshield M2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M2"
     },
     {
       "name": "block-chassis_shield_2-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_3-name",
-      "value": "Arcshield M3 [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M3 [L]"
     },
     {
       "name": "block-chassis_shield_3-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_3_m-name",
-      "value": "Arcshield M3 [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M3 [R]"
     },
     {
       "name": "block-chassis_shield_3_m-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_4-name",
-      "value": "Arcshield M4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M4"
     },
     {
       "name": "block-chassis_shield_4-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_5-name",
-      "value": "Arcshield M5 [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M5 [L]"
     },
     {
       "name": "block-chassis_shield_5-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_5_m-name",
-      "value": "Arcshield M5 [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M5 [R]"
     },
     {
       "name": "block-chassis_shield_5_m-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_6-name",
-      "value": "Arcshield M6 [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M6 [L]"
     },
     {
       "name": "block-chassis_shield_6-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_6_m-name",
-      "value": "Arcshield M6 [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M6 [R]"
     },
     {
       "name": "block-chassis_shield_6_m-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_7-name",
-      "value": "Arcshield M7",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M7"
     },
     {
       "name": "block-chassis_shield_7-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_8-name",
-      "value": "Arcshield M8",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M8"
     },
     {
       "name": "block-chassis_shield_8-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_9-name",
-      "value": "Arcshield M9 [L]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M9 [L]"
     },
     {
       "name": "block-chassis_shield_9-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_9_m-name",
-      "value": "Arcshield M9 [R]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M9 [R]"
     },
     {
       "name": "block-chassis_shield_9_m-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-chassis_shield_10-name",
-      "value": "Arcshield M10",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield M10"
     },
     {
       "name": "block-chassis_shield_10-desc",
-      "value": "A high-tech energy shield which recharges after taking damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech energy shield which recharges after taking damage."
     },
     {
       "name": "block-helium_112-name",
-      "value": "LTA 1x1x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "LTA 1x1x2"
     },
     {
       "name": "block-helium_112-desc",
-      "value": "A tiny tank of lighter-than-air gas.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A tiny tank of lighter-than-air gas."
     },
     {
       "name": "block-helium_123-name",
-      "value": "LTA 1x3x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "LTA 1x3x2"
     },
     {
       "name": "block-helium_123-desc",
-      "value": "A small tank of lighter-than-air gas.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small tank of lighter-than-air gas."
     },
     {
       "name": "block-helium_224-name",
-      "value": "LTA 2x2x4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "LTA 2x2x4"
     },
     {
       "name": "block-helium_224-desc",
-      "value": "A medium tank of lighter-than-air gas.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A medium tank of lighter-than-air gas."
     },
     {
       "name": "block-helium_335-name",
-      "value": "LTA 3x3x5",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "LTA 3x3x5"
     },
     {
       "name": "block-helium_335-desc",
-      "value": "A large tank of lighter-than-air gas.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A large tank of lighter-than-air gas."
     },
     {
       "name": "block-helium_348-name",
-      "value": "LTA 3x4x8",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "LTA 3x4x8"
     },
     {
       "name": "block-helium_348-desc",
-      "value": "A massive tank of lighter-than-air gas.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A massive tank of lighter-than-air gas."
     },
     {
       "name": "block-alpha_devonly_antigrav-name",
-      "value": "DevHax (antigrav)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DevHax (antigrav)"
     },
     {
       "name": "block-alpha_devonly_antigrav-desc",
-      "value": "DevHax (antigrav)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DevHax (antigrav)"
     },
     {
       "name": "block-mod_dash-name",
-      "value": "Mass Distortion Drive",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mass Distortion Drive"
     },
     {
       "name": "block-mod_dash-desc",
-      "value": "On activation, create a singularity that displaces bot in desired direction.\n\nStacking improves energy consumption.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, create a singularity that displaces bot in desired direction.\n\nStacking improves energy consumption."
     },
     {
       "name": "block-mod_flare-name",
-      "value": "Countermeasure Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Countermeasure Bay"
     },
     {
       "name": "block-mod_flare-desc",
-      "value": "On activation, grants temporary immunity to lock-ons and deploys a field that destroys nova projectiles and missiles.\n\nStacking grants additional charges.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, grants temporary immunity to lock-ons and deploys a field that destroys nova projectiles and missiles.\n\nStacking grants additional charges."
     },
     {
       "name": "block-mod_fuel-name",
-      "value": "Turbofuel Injector",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Turbofuel Injector"
     },
     {
       "name": "block-mod_fuel-desc",
-      "value": "On activation, expend turbofuel to tremendously increase thrust output of thrusters that align with the module.\n\nStacking improves energy consumption.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, expend turbofuel to tremendously increase thrust output of thrusters that align with the module.\n\nStacking improves energy consumption."
     },
     {
       "name": "block-mod_shockwave-name",
-      "value": "Force Concussor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Force Concussor"
     },
     {
       "name": "block-mod_shockwave-desc",
-      "value": "On activation, release a radial blast that damages and pushes enemy bots away.\n\nStacking increases blast force and radius.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, release a radial blast that damages and pushes enemy bots away.\n\nStacking increases blast force and radius."
     },
     {
       "name": "block-mod_overshield-name",
-      "value": "Personal Shield Generator",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Personal Shield Generator"
     },
     {
       "name": "block-mod_overshield-desc",
-      "value": "Passively creates a full-bot overshield that takes incoming damage before the bot does, with a slow recharge.\n\nStacking grants additional overshield.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Passively creates a full-bot overshield that takes incoming damage before the bot does, with a slow recharge.\n\nStacking grants additional overshield."
     },
     {
       "name": "block-mod_spoofer-name",
-      "value": "IFF Spoofer",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "IFF Spoofer"
     },
     {
       "name": "block-mod_spoofer-desc",
-      "value": "On activation, temporarily disguise your IFF signal to appear as an ally to your enemies, fooling mines and missile locks as well. Taking and dealing damage drains the effect faster.\n\nStacking grants additional disguide time.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, temporarily disguise your IFF signal to appear as an ally to your enemies, fooling mines and missile locks as well. Taking and dealing damage drains the effect faster.\n\nStacking grants additional disguide time."
     },
     {
       "name": "block-mod_forge-name",
-      "value": "Munitions Forge",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Munitions Forge"
     },
     {
       "name": "block-mod_forge-desc",
-      "value": "Passively restocks secondary weapon systems.\n\nStacking grants additional restock speed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Passively restocks secondary weapon systems.\n\nStacking grants additional restock speed."
     },
     {
       "name": "block-module_8-name",
-      "value": "Mod 8",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mod 8"
     },
     {
       "name": "block-module_8-desc",
-      "value": "Mod 8",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mod 8"
     },
     {
       "name": "block-module_9-name",
-      "value": "Mod 9",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mod 9"
     },
     {
       "name": "block-module_9-desc",
-      "value": "Mod 9",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mod 9"
     },
     {
       "name": "block-module_10-name",
-      "value": "Mod 10",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mod 10"
     },
     {
       "name": "block-module_10-desc",
-      "value": "Mod 10",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mod 10"
     },
     {
       "name": "block-ammo_box_small-name",
-      "value": "Small Ammo Box",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Ammo Box"
     },
     {
       "name": "block-ammo_box_small-desc",
-      "value": "Provides a small increase of reserve ammunition to supplement your equipped secondary weapon system.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Provides a small increase of reserve ammunition to supplement your equipped secondary weapon system."
     },
     {
       "name": "block-ammo_box_large-name",
-      "value": "Large Ammo Box",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Ammo Box"
     },
     {
       "name": "block-ammo_box_large-desc",
-      "value": "Provides a large increase of reserve ammunition to supplement your equipped secondary weapon system.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Provides a large increase of reserve ammunition to supplement your equipped secondary weapon system."
     },
     {
       "name": "block-energy_capacitor_small-name",
-      "value": "Small Energy Capacitor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Energy Capacitor"
     },
     {
       "name": "block-energy_capacitor_small-desc",
-      "value": "Provides a small increase of available energy to power your equipped modules.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Provides a small increase of available energy to power your equipped modules."
     },
     {
       "name": "block-energy_capacitor_large-name",
-      "value": "Large Energy Capacitor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Energy Capacitor"
     },
     {
       "name": "block-energy_capacitor_large-desc",
-      "value": "Provides a large increase of available energy to power your equipped modules.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Provides a large increase of available energy to power your equipped modules."
     },
     {
       "name": "block-alpha_isopod_cosmetic-name",
-      "value": "Hardhat Craig",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hardhat Craig"
     },
     {
       "name": "block-alpha_isopod_cosmetic-desc",
-      "value": "Our little isopod mascot, the original.\n\nDon't worry, this is just a decoy.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Our little isopod mascot, the original.\n\nDon't worry, this is just a decoy."
     },
     {
       "name": "block-cosm_isopod_xmas-name",
-      "value": "Xmas hat Craig",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Xmas hat Craig"
     },
     {
       "name": "block-cosm_isopod_xmas-desc",
-      "value": "Our little isopod mascot, in seasonal spirit!\n\nDon't worry, this is just a decoy.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Our little isopod mascot, in seasonal spirit!\n\nDon't worry, this is just a decoy."
     },
     {
       "name": "block-cosm_isopod_nwyrs23-name",
-      "value": "New Years Craig",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "New Years Craig"
     },
     {
       "name": "block-cosm_isopod_nwyrs23-desc",
-      "value": "Our little isopod mascot is wishing you a happy new year!\n\nDon't worry, this is just a decoy.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Our little isopod mascot is wishing you a happy new year!\n\nDon't worry, this is just a decoy."
     },
     {
       "name": "block-alpha_headlight_standard-name",
-      "value": "Standard Headlight",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Standard Headlight"
     },
     {
       "name": "block-alpha_headlight_standard-desc",
-      "value": "A flat headlight, for nighttime warfare.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A flat headlight, for nighttime warfare."
     },
     {
       "name": "block-alpha_headlight_popup-name",
-      "value": "Popup Headlight",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Popup Headlight"
     },
     {
       "name": "block-alpha_headlight_popup-desc",
-      "value": "Headlight variant",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Headlight variant"
     },
     {
       "name": "block-alpha_headlight_aimable-name",
-      "value": "Aiming Headlight",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Aiming Headlight"
     },
     {
       "name": "block-alpha_headlight_aimable-desc",
-      "value": "Headlight variant",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Headlight variant"
     },
     {
       "name": "block-alpha_vapor_cosmetic-name",
-      "value": "Vapor Trail",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Vapor Trail"
     },
     {
       "name": "block-alpha_vapor_cosmetic-desc",
-      "value": "Emits a constant trail of vapor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Emits a constant trail of vapor"
     },
     {
       "name": "block-cosm_sirenlight-name",
-      "value": "Siren Light",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Siren Light"
     },
     {
       "name": "block-cosm_sirenlight-desc",
-      "value": "Has lights, rotates.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Has lights, rotates."
     },
     {
       "name": "block-cosm_sirenlight_orange-name",
-      "value": "Siren Light (Orange)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Siren Light (Orange)"
     },
     {
       "name": "block-cosm_sirenlight_orange-desc",
-      "value": "Has orange lights, rotates.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Has orange lights, rotates."
     },
     {
       "name": "block-horn-name",
-      "value": "Horn",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Horn"
     },
     {
       "name": "block-horn-desc",
-      "value": "Beep beep",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Beep beep"
     },
     {
       "name": "block-cosm_arm-name",
-      "value": "Servo Arm",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Servo Arm"
     },
     {
       "name": "block-cosm_arm-desc",
-      "value": "Well, never know when you're going to find a perfectly good rock.\n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Well, never know when you're going to find a perfectly good rock.\n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_exhaust-name",
-      "value": "Exhaust Prism",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Exhaust Prism"
     },
     {
       "name": "block-cosm_exhaust-desc",
-      "value": "Why limit pollution to just Earth?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Why limit pollution to just Earth?"
     },
     {
       "name": "block-cosm_kitt-name",
-      "value": "Oscillating Light Strip",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Oscillating Light Strip"
     },
     {
       "name": "block-cosm_kitt-desc",
-      "value": "Someone in Osprey R&D was a fan of old sci-fi.\n\nDoes not come with voice module.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Someone in Osprey R&D was a fan of old sci-fi.\n\nDoes not come with voice module."
     },
     {
       "name": "block-cosm_smallantenna-name",
-      "value": "Small Antenna",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Antenna"
     },
     {
       "name": "block-cosm_smallantenna-desc",
-      "value": "Comes with jiggle physics! \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Comes with jiggle physics! \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_antenna_side-name",
-      "value": "Side Antenna",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Side Antenna"
     },
     {
       "name": "block-cosm_antenna_side-desc",
-      "value": "Comes with side mounted jiggle physics! \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Comes with side mounted jiggle physics! \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_largeantenna-name",
-      "value": "Large Antenna",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Antenna"
     },
     {
       "name": "block-cosm_largeantenna-desc",
-      "value": "Enables you to call into One Mars Radio.* \n\n*Does not actually enable you to call into One Mars Radio.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Enables you to call into One Mars Radio.* \n\n*Does not actually enable you to call into One Mars Radio."
     },
     {
       "name": "block-cosm_smallspike-name",
-      "value": "Small Spike",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Spike"
     },
     {
       "name": "block-cosm_smallspike-desc",
-      "value": "Doesn't do any damage. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Doesn't do any damage. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_largespike-name",
-      "value": "Large Spike",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Spike"
     },
     {
       "name": "block-cosm_largespike-desc",
-      "value": "Doesn't do any damage, but larger. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Doesn't do any damage, but larger. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_smalltailspike-name",
-      "value": "Small Tailspike",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Tailspike"
     },
     {
       "name": "block-cosm_smalltailspike-desc",
-      "value": "Doesn't help your aerodynamics. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Doesn't help your aerodynamics. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_largetailspike-name",
-      "value": "Large Tailspike",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Tailspike"
     },
     {
       "name": "block-cosm_largetailspike-desc",
-      "value": "Doesn't help your aerodynamics, but larger. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Doesn't help your aerodynamics, but larger. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_smallnosecone-name",
-      "value": "Small Nosecone",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Nosecone"
     },
     {
       "name": "block-cosm_smallnosecone-desc",
-      "value": "Doesn't help your aerodynamics, but looks cool. \n\nPurely cool.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Doesn't help your aerodynamics, but looks cool. \n\nPurely cool."
     },
     {
       "name": "block-cosm_largenosecone-name",
-      "value": "Large Nosecone",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Nosecone"
     },
     {
       "name": "block-cosm_largenosecone-desc",
-      "value": "Doesn't help your aerodynamics, but larger. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Doesn't help your aerodynamics, but larger. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_mechhead-name",
-      "value": "Vertec� Sensor Array",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Vertec� Sensor Array"
     },
     {
       "name": "block-cosm_mechhead-desc",
-      "value": "Twin-Linked Vertec� Mk.IV Gauss Rifles not included. \n\nPurely cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Twin-Linked Vertec� Mk.IV Gauss Rifles not included. \n\nPurely cosmetic"
     },
     {
       "name": "block-cosm_screwgreeble-name",
-      "value": "Screw Head",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Screw Head"
     },
     {
       "name": "block-cosm_screwgreeble-desc",
-      "value": "Speculated to improve the structural stability of fish-inspired crafts by up to 10%. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Speculated to improve the structural stability of fish-inspired crafts by up to 10%. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_pan9k-name",
-      "value": "PAN 9000 (Space)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PAN 9000 (Space)"
     },
     {
       "name": "block-cosm_pan9k-desc",
-      "value": "I'm sorry, Brenn. I'm afraid I can't do that. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "I'm sorry, Brenn. I'm afraid I can't do that. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_pan9a-name",
-      "value": "PAN 9000 (Skies)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PAN 9000 (Skies)"
     },
     {
       "name": "block-cosm_pan9a-desc",
-      "value": "Not to be trusted near space infrastructure. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Not to be trusted near space infrastructure. \n\nPurely cosmetic."
     },
     {
       "name": "block-paint_diagcube-name",
-      "value": "Normal Cube (Diagonal Paint)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Cube (Diagonal Paint)"
     },
     {
       "name": "block-paint_diagcube-desc",
-      "value": "A full chassis cube with an alternate paint job.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A full chassis cube with an alternate paint job."
     },
     {
       "name": "block-paint_halfcube-name",
-      "value": "Normal Cube (Half Paint)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Normal Cube (Half Paint)"
     },
     {
       "name": "block-paint_halfcube-desc",
-      "value": "A full chassis cube with an alternate paint job.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A full chassis cube with an alternate paint job."
     },
     {
       "name": "block-alpha_ventcube-name",
-      "value": "Vent Cube",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Vent Cube"
     },
     {
       "name": "block-alpha_ventcube-desc",
-      "value": "A chassis cube with only a mild chance of containing infiltrators.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A chassis cube with only a mild chance of containing infiltrators."
     },
     {
       "name": "block-cosm_vent_long-name",
-      "value": "Long Vent",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Long Vent"
     },
     {
       "name": "block-cosm_vent_long-desc",
-      "value": "A 2 block long vent with only a slightly larger chance of containing infiltrators.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2 block long vent with only a slightly larger chance of containing infiltrators."
     },
     {
       "name": "block-cosm_stickerplate1-name",
-      "value": "Osprey 1x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Osprey 1x2"
     },
     {
       "name": "block-cosm_stickerplate1-desc",
-      "value": "A 1x2 Osprey sticker. \n\nWe will not pay you for using this.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x2 Osprey sticker. \n\nWe will not pay you for using this."
     },
     {
       "name": "block-cosm_stickerplate2-name",
-      "value": "Spacetek 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Spacetek 2x2"
     },
     {
       "name": "block-cosm_stickerplate2-desc",
-      "value": "A 2x2 Spacetek Dynamics sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Spacetek Dynamics sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate3-name",
-      "value": "Hypox 2x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hypox 2x3"
     },
     {
       "name": "block-cosm_stickerplate3-desc",
-      "value": "A 2x3 Hypox Mining Company sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x3 Hypox Mining Company sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate4-name",
-      "value": "Osprey Bird 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Osprey Bird 2x2"
     },
     {
       "name": "block-cosm_stickerplate4-desc",
-      "value": "A 2x2 Osprey Bird sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Osprey Bird sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate5-name",
-      "value": "Frontiersmen 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Frontiersmen 2x2"
     },
     {
       "name": "block-cosm_stickerplate5-desc",
-      "value": "A 2x2 Frontiersmen faction sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Frontiersmen faction sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate6-name",
-      "value": "RSR CO. 2x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "RSR CO. 2x3"
     },
     {
       "name": "block-cosm_stickerplate6-desc",
-      "value": "A 2x3 Red Sand Rail Company sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x3 Red Sand Rail Company sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate7-name",
-      "value": "Stripes 1x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stripes 1x2"
     },
     {
       "name": "block-cosm_stickerplate7-desc",
-      "value": "A 1x2 hazard stripes sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x2 hazard stripes sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate8-name",
-      "value": "Stripes 1x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stripes 1x3"
     },
     {
       "name": "block-cosm_stickerplate8-desc",
-      "value": "A 1x3 hazard stripes sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x3 hazard stripes sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate15-name",
-      "value": "Stripes 1x2 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stripes 1x2 [M]"
     },
     {
       "name": "block-cosm_stickerplate15-desc",
-      "value": "A 1x2 mirrored hazard stripes sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x2 mirrored hazard stripes sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate16-name",
-      "value": "Stripes 1x3 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stripes 1x3 [M]"
     },
     {
       "name": "block-cosm_stickerplate16-desc",
-      "value": "A 1x3 mirrored hazard stripes sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x3 mirrored hazard stripes sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate9-name",
-      "value": "Medic 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Medic 2x2"
     },
     {
       "name": "block-cosm_stickerplate9-desc",
-      "value": "A 2x2 Medic Sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Medic Sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate10-name",
-      "value": "Vertec 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Vertec 2x2"
     },
     {
       "name": "block-cosm_stickerplate10-desc",
-      "value": "A 2x2 Vertec Sniper Sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Vertec Sniper Sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate11-name",
-      "value": "Nova 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova 2x2"
     },
     {
       "name": "block-cosm_stickerplate11-desc",
-      "value": "A 2x2 Nova Bomber Sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Nova Bomber Sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate12-name",
-      "value": "Brawler 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Brawler 2x2"
     },
     {
       "name": "block-cosm_stickerplate12-desc",
-      "value": "A 2x2 Brawler Sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x2 Brawler Sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate13-name",
-      "value": "Money 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Money 2x2"
     },
     {
       "name": "block-cosm_stickerplate13-desc",
-      "value": "Why would you buy this? \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Why would you buy this? \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate14-name",
-      "value": "Scrip 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Scrip 2x2"
     },
     {
       "name": "block-cosm_stickerplate14-desc",
-      "value": "Why would you buy this, but premium? \nNo, really?? \nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Why would you buy this, but premium? \nNo, really?? \nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate17-name",
-      "value": "Lousy Sticker 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Lousy Sticker 2x2"
     },
     {
       "name": "block-cosm_stickerplate17-desc",
-      "value": "A token of our appreciation for playing the Alpha. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A token of our appreciation for playing the Alpha. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate18-name",
-      "value": "Alpha Sticker 1x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Alpha Sticker 1x3"
     },
     {
       "name": "block-cosm_stickerplate18-desc",
-      "value": "A token of our appreciation for playing the Alpha. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A token of our appreciation for playing the Alpha. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate19-name",
-      "value": "PH 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PH 2x2"
     },
     {
       "name": "block-cosm_stickerplate19-desc",
-      "value": "3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "3"
     },
     {
       "name": "block-cosm_stickerplate20-name",
-      "value": "PH 2x2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PH 2x2"
     },
     {
       "name": "block-cosm_stickerplate20-desc",
-      "value": "4",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "4"
     },
     {
       "name": "block-cosm_stickerplate21-name",
-      "value": "FSA 2x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "FSA 2x3"
     },
     {
       "name": "block-cosm_stickerplate21-desc",
-      "value": "A 2x3 Federated States Sticker. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 2x3 Federated States Sticker. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_stickerplate22-name",
-      "value": "PH 2x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PH 2x3"
     },
     {
       "name": "block-cosm_stickerplate22-desc",
-      "value": "6",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "6"
     },
     {
       "name": "block-cosm_sticker_number_0-name",
-      "value": "0 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "0 1x1"
     },
     {
       "name": "block-cosm_sticker_number_0-desc",
-      "value": "A 1x1 sticker of the number 0. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 0. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_1-name",
-      "value": "1 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "1 1x1"
     },
     {
       "name": "block-cosm_sticker_number_1-desc",
-      "value": "A 1x1 sticker of the number 1. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 1. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_2-name",
-      "value": "2 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "2 1x1"
     },
     {
       "name": "block-cosm_sticker_number_2-desc",
-      "value": "A 1x1 sticker of the number 2. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 2. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_3-name",
-      "value": "3 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "3 1x1"
     },
     {
       "name": "block-cosm_sticker_number_3-desc",
-      "value": "A 1x1 sticker of the number 3. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 3. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_4-name",
-      "value": "4 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "4 1x1"
     },
     {
       "name": "block-cosm_sticker_number_4-desc",
-      "value": "A 1x1 sticker of the number 4. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 4. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_5-name",
-      "value": "5 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "5 1x1"
     },
     {
       "name": "block-cosm_sticker_number_5-desc",
-      "value": "A 1x1 sticker of the number 5. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 5. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_6-name",
-      "value": "6 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "6 1x1"
     },
     {
       "name": "block-cosm_sticker_number_6-desc",
-      "value": "A 1x1 sticker of the number 6. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 6. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_7-name",
-      "value": "7 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "7 1x1"
     },
     {
       "name": "block-cosm_sticker_number_7-desc",
-      "value": "A 1x1 sticker of the number 7. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 7. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_8-name",
-      "value": "8 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "8 1x1"
     },
     {
       "name": "block-cosm_sticker_number_8-desc",
-      "value": "A 1x1 sticker of the number 8. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 8. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_9-name",
-      "value": "9 1x1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "9 1x1"
     },
     {
       "name": "block-cosm_sticker_number_9-desc",
-      "value": "A 1x1 sticker of the number 9. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A 1x1 sticker of the number 9. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_0_m-name",
-      "value": "0 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "0 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_0_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 0. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 0. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_1_m-name",
-      "value": "1 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "1 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_1_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 1. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 1. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_2_m-name",
-      "value": "2 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "2 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_2_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 2. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 2. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_3_m-name",
-      "value": "3 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "3 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_3_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 3. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 3. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_4_m-name",
-      "value": "4 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "4 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_4_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 4. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 4. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_5_m-name",
-      "value": "5 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "5 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_5_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 5. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 5. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_6_m-name",
-      "value": "6 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "6 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_6_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 6. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 6. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_7_m-name",
-      "value": "7 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "7 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_7_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 7. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 7. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_8_m-name",
-      "value": "8 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "8 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_8_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 8. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 8. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_sticker_number_9_m-name",
-      "value": "9 1x1 [M]",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "9 1x1 [M]"
     },
     {
       "name": "block-cosm_sticker_number_9_m-desc",
-      "value": "A mirrored 1x1 sticker of the number 9. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mirrored 1x1 sticker of the number 9. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_dev_brenn-name",
-      "value": "Brenn Cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Brenn Cosmetic"
     },
     {
       "name": "block-cosm_dev_brenn-desc",
-      "value": "Only for Brenn. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only for Brenn. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_dev_pan-name",
-      "value": "Pan Cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Pan Cosmetic"
     },
     {
       "name": "block-cosm_dev_pan-desc",
-      "value": "Only for Pan. \n\nPurely OSCosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only for Pan. \n\nPurely OSCosmetic."
     },
     {
       "name": "block-cosm_dev_kip-name",
-      "value": "Kip Cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Kip Cosmetic"
     },
     {
       "name": "block-cosm_dev_kip-desc",
-      "value": "Only for Kip. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only for Kip. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_dev_snip-name",
-      "value": "Snip Cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Snip Cosmetic"
     },
     {
       "name": "block-cosm_dev_snip-desc",
-      "value": "Only for Snip. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only for Snip. \n\nPurely cosmetic."
     },
     {
       "name": "block-cosm_dev_blade-name",
-      "value": "Blade Cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Blade Cosmetic"
     },
     {
       "name": "block-cosm_dev_blade-desc",
-      "value": "Only for Blade. \n\nPurely cosmetic.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only for Blade. \n\nPurely cosmetic."
     },
     {
       "name": "error",
-      "value": "Error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Error"
     },
     {
       "name": "try-again-later",
-      "value": "Please try again later",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Please try again later"
     },
     {
       "name": "authentication-failure",
-      "value": "Authentication failure",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Authentication failure"
     },
     {
       "name": "server-lookup-error",
-      "value": "Failed to discover server: {placeholder}",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to discover server: {placeholder}"
     },
     {
       "name": "server-connect-error",
-      "value": "Failed to connect to server",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to connect to server"
     },
     {
       "name": "transaction-process-header",
-      "value": "Processing...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Processing..."
     },
     {
       "name": "transaction-process-description",
-      "value": "Validating transaction with server",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Validating transaction with server"
     },
     {
       "name": "transaction-failed-header",
-      "value": "Transaction Failed",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Transaction Failed"
     },
     {
       "name": "transaction-failed-description",
-      "value": "Unable to authenticate transaction",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to authenticate transaction"
     },
     {
       "name": "build-placement-error-title",
-      "value": "Placement error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placement error"
     },
     {
       "name": "build-placement-error-maxcpu",
-      "value": "Placement would exceed maximum complexity limits",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placement would exceed maximum complexity limits"
     },
     {
       "name": "build-placement-error-maxcosmcpu",
-      "value": "Placement would exceed maximum cosmetic limits",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Placement would exceed maximum cosmetic limits"
     },
     {
       "name": "build-placement-error-noblocks",
-      "value": "No more blocks of that type (%d)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "No more blocks of that type (%d)"
     },
     {
       "name": "build-placement-error-twocore",
-      "value": "Robot already has a core",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot already has a core"
     },
     {
       "name": "build-placement-error-archetype",
-      "value": "Component incompatible with parts already on bot",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Component incompatible with parts already on bot"
     },
     {
       "name": "build-placement-error-module",
-      "value": "Only four types of modules are permitted on a bot",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only four types of modules are permitted on a bot"
     },
     {
       "name": "build-placement-error-collide",
-      "value": "Unable to replace all parts (collision, inventory count, etc.)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to replace all parts (collision, inventory count, etc.)"
     },
     {
       "name": "build-advanced-header",
-      "value": "ADVANCED MODE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "ADVANCED MODE"
     },
     {
       "name": "build-advanced-desc",
-      "value": "Place parts with advanced orientation control.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Place parts with advanced orientation control."
     },
     {
       "name": "build-cust-held-cosmetic",
-      "value": "Held Cosmetic",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Held Cosmetic"
     },
     {
       "name": "build-cust-equipped-cosmetics",
-      "value": "Equipped Cosmetics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Equipped Cosmetics"
     },
     {
       "name": "build-cust-incompatible-part",
-      "value": "Incompatible with part!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Incompatible with part!"
     },
     {
       "name": "robot-validate-error-title",
-      "value": "Robot invalid",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot invalid"
     },
     {
       "name": "robot-validate-error-zerocore",
-      "value": "Robot does not have a core",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot does not have a core"
     },
     {
       "name": "robot-validate-error-twocore",
-      "value": "Robot contains two cores",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot contains two cores"
     },
     {
       "name": "robot-validate-error-maxcpu",
-      "value": "Robot contains too many parts",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot contains too many parts"
     },
     {
       "name": "robot-validate-error-maxcosmcpu",
-      "value": "Robot contains too many cosmetics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot contains too many cosmetics"
     },
     {
       "name": "robot-validate-error-disconnect",
-      "value": "Robot contains disconnected parts",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot contains disconnected parts"
     },
     {
       "name": "robot-validate-no-functional",
-      "value": "Robot must contain functional parts",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot must contain functional parts"
     },
     {
       "name": "network-connection-lost-title",
-      "value": "Connection lost?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Connection lost?"
     },
     {
       "name": "network-connection-lost-info",
-      "value": "%sec seconds...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "%sec seconds..."
     },
     {
       "name": "matchmaking-failed-title",
-      "value": "Matchmaking failed",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Matchmaking failed"
     },
     {
       "name": "matchmaking-failed-body",
-      "value": "An unknown error occurred. Please try again. If the error persists, let devs know.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An unknown error occurred. Please try again. If the error persists, let devs know."
     },
     {
       "name": "only-host-pick-mode",
-      "value": "Only the host may select the gamemode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Only the host may select the gamemode"
     },
     {
       "name": "matchmaking-preparing",
-      "value": "Match preparing...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Match preparing..."
     },
     {
       "name": "matchmaking-ready",
-      "value": "Match assigned!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Match assigned!"
     },
     {
       "name": "matchmaking-estimated",
-      "value": "Estimated queue time:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Estimated queue time:"
     },
     {
       "name": "paint-premiumonly-title",
-      "value": "No Procelio Premium",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "No Procelio Premium"
     },
     {
       "name": "paint-premiumonly-body",
-      "value": "Custom paint palettes only available with Procelio Premium",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Custom paint palettes only available with Procelio Premium"
     },
     {
       "name": "delete-bot-title",
-      "value": "Are you sure?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Are you sure?"
     },
     {
       "name": "delete-bot-body",
-      "value": "Bot '%b' may not be recoverable",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Bot '%b' may not be recoverable"
     },
     {
       "name": "clipboard-replace-bot-title",
-      "value": "Are you sure?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Are you sure?"
     },
     {
       "name": "clipboard-replace-bot-body",
-      "value": "Replace '%b1' with clipboard contents '%b2'",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Replace '%b1' with clipboard contents '%b2'"
     },
     {
       "name": "delete-palette-title",
-      "value": "Are you sure?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Are you sure?"
     },
     {
       "name": "delete-palette-body",
-      "value": "Palette '%b' will not be recoverable",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Palette '%b' will not be recoverable"
     },
     {
       "name": "delete-local-prefab-title",
-      "value": "Are you sure?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Are you sure?"
     },
     {
       "name": "delete-local-prefab-body",
-      "value": "Prefab '%b' may not be recoverable",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Prefab '%b' may not be recoverable"
     },
     {
       "name": "import-botfile-message",
-      "value": "Legacy bot '%b' imported!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Legacy bot '%b' imported!"
     },
     {
       "name": "prefab-instructions-upload",
-      "value": "Select bay to upload",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Select bay to upload"
     },
     {
       "name": "prefab-instructions-export",
-      "value": "Select bay to export",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Select bay to export"
     },
     {
       "name": "prefab-instructions-import",
-      "value": "Select bay to overwrite",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Select bay to overwrite"
     },
     {
       "name": "network-out-of-date-title",
-      "value": "Incompatible net-code version",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Incompatible net-code version"
     },
     {
       "name": "network-out-of-date-body",
-      "value": "Your client is incompatible with the current game servers. Please update to the newest version via our website [procelio.com].",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Your client is incompatible with the current game servers. Please update to the newest version via our website [procelio.com]."
     },
     {
       "name": "chat-error",
-      "value": "Chat Error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Chat Error"
     },
     {
       "name": "chat-failed-to-join-room",
-      "value": "Failed to join chat room. Cause: {placeholder}",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to join chat room. Cause: {placeholder}"
     },
     {
       "name": "chat-failed-join-cause-full",
-      "value": "Room is full",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Room is full"
     },
     {
       "name": "chat-failed-join-cause-present",
-      "value": "You're already in the room",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "You're already in the room"
     },
     {
       "name": "chat-failed-join-cause-404",
-      "value": "Not found",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Not found"
     },
     {
       "name": "chat-failed-join-cause-auth",
-      "value": "Unauthorized",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unauthorized"
     },
     {
       "name": "chat-social-status-failure",
-      "value": "Failed to update social status with {placeholder} (limit reached)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to update social status with {placeholder} (limit reached)"
     },
     {
       "name": "chat-social-status-failure500",
-      "value": "Failed to update social status with {placeholder} (server error)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to update social status with {placeholder} (server error)"
     },
     {
       "name": "chat-msg-squadinvite",
-      "value": "Join Squad (chat)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Join Squad (chat)"
     },
     {
       "name": "chat-msg-mminvite",
-      "value": "Join Squad (queue)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Join Squad (queue)"
     },
     {
       "name": "confirm-user-operation",
-      "value": "Confirm player operation",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Confirm player operation"
     },
     {
       "name": "mode-free-for-all",
-      "value": "Free For All",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Free For All"
     },
     {
       "name": "mode-contest-capture",
-      "value": "Contested Capture Point",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Contested Capture Point"
     },
     {
       "name": "mode-test",
-      "value": "Prototype Development",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Prototype Development"
     },
     {
       "name": "mode-desc-free-for-all",
-      "value": "Everyone is your enemy, fight for your life in this mode.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Everyone is your enemy, fight for your life in this mode."
     },
     {
       "name": "mode-desc-contest-capture",
-      "value": "Fight for land in this dynamic king of the hill mode. Capture points spawn randomly around the map, fight for control and stay on the point to capture it.\n\nFirst team to five captures wins, otherwise most captures on time out wins.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fight for land in this dynamic king of the hill mode. Capture points spawn randomly around the map, fight for control and stay on the point to capture it.\n\nFirst team to five captures wins, otherwise most captures on time out wins."
     },
     {
       "name": "mode-desc-test",
-      "value": "Create, test, and refine robot designs within the HOME Station.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Create, test, and refine robot designs within the HOME Station."
     },
     {
       "name": "mode-rules-contest-capture",
-      "value": "- Multiplayer PvP\n- Drop Deck Size: 3\n- Amp Limit: 2000\n- Respawns Enabled\n- Server Bots Enabled\n- Dynamic Time Limit",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "- Multiplayer PvP\n- Drop Deck Size: 3\n- Amp Limit: 2000\n- Respawns Enabled\n- Server Bots Enabled\n- Dynamic Time Limit"
     },
     {
       "name": "mode-asset-extraction",
-      "value": "Asset Extraction",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Asset Extraction"
     },
     {
       "name": "mode-desc-asset-extraction",
-      "value": "Bring points back to your base",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Bring points back to your base"
     },
     {
       "name": "mode-rules-asset-extraction",
-      "value": "- Multiplayer PvP\n- Drop Deck Size: 3\n- Amp Limit: 2000\n- Respawns Enabled\n- Server Bots Enabled\n- Fixed Time Limit",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "- Multiplayer PvP\n- Drop Deck Size: 3\n- Amp Limit: 2000\n- Respawns Enabled\n- Server Bots Enabled\n- Fixed Time Limit"
     },
     {
       "name": "you-have-died",
-      "value": "You have died.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "You have died."
     },
     {
       "name": "respawning-time",
-      "value": "Respawning in %s seconds...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Respawning in %s seconds..."
     },
     {
       "name": "chat-broadcast",
-      "value": "Message from the devs",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Message from the devs"
     },
     {
       "name": "replay-save-failed",
-      "value": "Failed to save replay:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to save replay:"
     },
     {
       "name": "dependencies-licenses-credits",
-      "value": "Dependencies, Licenses and Credits",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Dependencies, Licenses and Credits"
     },
     {
       "name": "replay-browser",
-      "value": "Replay Browser",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Replay Browser"
     },
     {
       "name": "squad-readystate-true",
-      "value": "READY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "READY"
     },
     {
       "name": "squad-readystate-false",
-      "value": "NOT READY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "NOT READY"
     },
     {
       "name": "ui-button-ok",
-      "value": "Ok",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ok"
     },
     {
       "name": "ui-button-continue",
-      "value": "Continue",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Continue"
     },
     {
       "name": "ui-button-cancel",
-      "value": "Cancel",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cancel"
     },
     {
       "name": "ui-button-reset",
-      "value": "Reset",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Reset"
     },
     {
       "name": "ui-button-select",
-      "value": "Select",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Select"
     },
     {
       "name": "ui-button-remove",
-      "value": "Remove",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Remove"
     },
     {
       "name": "ui-button-add",
-      "value": "Add",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Add"
     },
     {
       "name": "ui-button-return",
-      "value": "Return",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Return"
     },
     {
       "name": "clear-prefab-slot",
-      "value": "Clear Slot",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Clear Slot"
     },
     {
       "name": "save-error",
-      "value": "Save Error",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Save Error"
     },
     {
       "name": "save-error-tech-unlocked",
-      "value": "Bot contains blocks not unlocked yet",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Bot contains blocks not unlocked yet"
     },
     {
       "name": "save-error-be-a-good-influence",
-      "value": "Be a good influence and name your bot something respectable, alright?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Be a good influence and name your bot something respectable, alright?"
     },
     {
       "name": "save-error-unknown-tell-devs",
-      "value": "Failed to save robot: {cause} (tell devs)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Failed to save robot: {cause} (tell devs)"
     },
     {
       "name": "save-error-probably-over-capacity",
-      "value": "Unable to save; robot complexity {seen} exceededs limit {limit}\n\n(sorry, we probably rebalanced things)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unable to save; robot complexity {seen} exceededs limit {limit}\n\n(sorry, we probably rebalanced things)"
     },
     {
       "name": "save-error-bad-robot",
-      "value": "Invalid robot (unknown cause; call devs)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Invalid robot (unknown cause; call devs)"
     },
     {
       "name": "save-error-over-complexity",
-      "value": "Robot complexity over serverside limits",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Robot complexity over serverside limits"
     },
     {
       "name": "save-error-over-cosmetic-complexity",
-      "value": "Bot cosmetic complexity over serverside limits",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Bot cosmetic complexity over serverside limits"
     },
     {
       "name": "buy-garage",
-      "value": "Purchase Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Purchase Garage Bay"
     },
     {
       "name": "buy-garage-cap",
-      "value": "You have the maximum number of purchaseable garage bays",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "You have the maximum number of purchaseable garage bays"
     },
     {
       "name": "buy-garage-funds",
-      "value": "You lack sufficient funds to purchase a garage bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "You lack sufficient funds to purchase a garage bay"
     },
     {
       "name": "rewards-notification",
-      "value": "After disconnecting from a match, you were awarded {money}",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "After disconnecting from a match, you were awarded {money}"
     },
     {
       "name": "delete-account-header",
-      "value": "WARNING: Account Deletion",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "WARNING: Account Deletion"
     },
     {
       "name": "delete-account-body",
-      "value": "A request to delete your account has been submitted. Please re-login to confirm the request.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A request to delete your account has been submitted. Please re-login to confirm the request."
     },
     {
       "name": "delete-account-confirmbody",
-      "value": "The request to delete your account has been confirmed.\n Note: deletion will be cancelled if you log in again in the next 14 days.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The request to delete your account has been confirmed.\n Note: deletion will be cancelled if you log in again in the next 14 days."
     },
     {
       "name": "dsar-account-header",
-      "value": "Request Account Data",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Request Account Data"
     },
     {
       "name": "dsar-account-body",
-      "value": "A request for a report of your account data has been submitted. Please re-login to confirm the request.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A request for a report of your account data has been submitted. Please re-login to confirm the request."
     },
     {
       "name": "dsar-account-confirmbody",
-      "value": "The request for your account data has been confirmed, though it may take some time to compile. Use this code to fetch it",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The request for your account data has been confirmed, though it may take some time to compile. Use this code to fetch it"
     },
     {
       "name": "internal-server-error",
-      "value": "An internal server error occurred. Maybe try again.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An internal server error occurred. Maybe try again."
     },
     {
       "name": "dsar-query-notfound",
-      "value": "No DSAR response with that code is ready yet.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "No DSAR response with that code is ready yet."
     },
     {
       "name": "dsar-query-ok",
-      "value": "Data ready for download! Use the provided URL in the next hour:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Data ready for download! Use the provided URL in the next hour:"
     },
     {
       "name": "account-operation-header",
-      "value": "WARNING: Pending Account Operation",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "WARNING: Pending Account Operation"
     },
     {
       "name": "account-operation-body",
-      "value": "A pending account operation will be confirmed by login. Proceed?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A pending account operation will be confirmed by login. Proceed?"
     },
     {
       "name": "account-operation-error",
-      "value": "An error occurred. The account operation was not confirmed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An error occurred. The account operation was not confirmed."
     },
     {
       "name": "steam-invite-err-header",
-      "value": "Error setting invite",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Error setting invite"
     },
     {
       "name": "steam-invite-err-body",
-      "value": "An error occurred. Cause code: ${causecode}",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An error occurred. Cause code: ${causecode}"
     },
     {
       "name": "build-mode-build",
-      "value": "Building Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Building Mode"
     },
     {
       "name": "build-mode-paint",
-      "value": "Painting Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Painting Mode"
     },
     {
       "name": "build-mode-customize",
-      "value": "Configure Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Configure Mode"
     },
     {
       "name": "score-kills",
-      "value": "Kills",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Kills"
     },
     {
       "name": "score-deaths",
-      "value": "Deaths",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Deaths"
     },
     {
       "name": "score-assists",
-      "value": "Assists",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Assists"
     },
     {
       "name": "score-damagegiven",
-      "value": "DMG Dealt",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DMG Dealt"
     },
     {
       "name": "score-damagetaken",
-      "value": "DMG Taken",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DMG Taken"
     },
     {
       "name": "score-damagehealed",
-      "value": "Healed",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Healed"
     },
     {
       "name": "score-timeconnected",
-      "value": "Time In Match",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Time In Match"
     },
     {
       "name": "score-objective",
-      "value": "Objective Time",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Objective Time"
     },
     {
       "name": "score-objectivepointsgenerated",
-      "value": "Points First Claimed",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Points First Claimed"
     },
     {
       "name": "score-objectivepointsscored",
-      "value": "Points Deposited",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Points Deposited"
     },
     {
       "name": "gameend-exit-match",
-      "value": "Claim Payment",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Claim Payment"
     },
     {
       "name": "gameend-exiting-in",
-      "value": "Returing to Orbit in %t...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Returing to Orbit in %t..."
     },
     {
       "name": "flip-instruction-1",
-      "value": "PRESS ${DriveFlipBot} TO JUMP",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "PRESS ${DriveFlipBot} TO JUMP"
     },
     {
       "name": "flip-instruction-2",
-      "value": "HOLD ${DriveFlipBot} TO FLIP",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "HOLD ${DriveFlipBot} TO FLIP"
     },
     {
       "name": "flip-instruction-3",
-      "value": "ROTATE BOT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "ROTATE BOT"
     },
     {
       "name": "flip-instruction-4",
-      "value": "RELEASE ${DriveFlipBot} TO DROP",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "RELEASE ${DriveFlipBot} TO DROP"
     },
     {
       "name": "energy-overdraw-nocharge",
-      "value": "CRITICAL ENERGY DRAW - RESTARTING",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "CRITICAL ENERGY DRAW - RESTARTING"
     },
     {
       "name": "energy-overdraw-charging",
-      "value": "RECHARGING CAPACITOR - STAND BY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "RECHARGING CAPACITOR - STAND BY"
     },
     {
       "name": "asset-extraction-shuttle-approach",
-      "value": "On Approach",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On Approach"
     },
     {
       "name": "asset-extraction-shuttle-loading",
-      "value": "Loading Assets",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Loading Assets"
     },
     {
       "name": "asset-extraction-shuttle-departing",
-      "value": "Departing",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Departing"
     },
     {
       "name": "asset-extraction-shuttle-abort",
-      "value": "Aborting Pickup",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Aborting Pickup"
     },
     {
       "name": "assetextract-bank-depositing",
-      "value": "Depositing Points...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Depositing Points..."
     },
     {
       "name": "assetextract-bank-stealing",
-      "value": "Stealing Points...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stealing Points..."
     },
     {
       "name": "match-connecting",
-      "value": "Connecting...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Connecting..."
     },
     {
       "name": "match-loading",
-      "value": "Loading Data...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Loading Data..."
     },
     {
       "name": "tech-1-name",
-      "value": "Electrolaser Carbine",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Electrolaser Carbine"
     },
     {
       "name": "tech-1-desc",
-      "value": "A reliable mid-range cannon good for all engagements. All primaries have infinite ammunition. \n\nOsprey standard issue.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A reliable mid-range cannon good for all engagements. All primaries have infinite ammunition. \n\nOsprey standard issue."
     },
     {
       "name": "tech-2-name",
-      "value": "Gauss Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gauss Rifle"
     },
     {
       "name": "tech-2-desc",
-      "value": "A long-distance, high velocity sniper cannon with a shell-loading magazine.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A long-distance, high velocity sniper cannon with a shell-loading magazine."
     },
     {
       "name": "tech-3-name",
-      "value": "Nova Cannon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Nova Cannon"
     },
     {
       "name": "tech-3-desc",
-      "value": "A recharging artillery cannon that fires a volley of unstable energy payloads.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A recharging artillery cannon that fires a volley of unstable energy payloads."
     },
     {
       "name": "tech-4-name",
-      "value": "Flux Weaver",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flux Weaver"
     },
     {
       "name": "tech-4-desc",
-      "value": "A continuous beam weapon that repairs allied bots and damages enemies.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A continuous beam weapon that repairs allied bots and damages enemies."
     },
     {
       "name": "tech-5-name",
-      "value": "Rivet Rifle",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Rivet Rifle"
     },
     {
       "name": "tech-5-desc",
-      "value": "A mid-range improvised cannon that fires superheated rivets from a magazine",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mid-range improvised cannon that fires superheated rivets from a magazine"
     },
     {
       "name": "tech-6-name",
-      "value": "Cerberus UMRL",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cerberus UMRL"
     },
     {
       "name": "tech-6-desc",
-      "value": "A mid-range cannon that fires a manually-loaded volley of unguided rockets.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mid-range cannon that fires a manually-loaded volley of unguided rockets."
     },
     {
       "name": "tech-51-name",
-      "value": "Minelayer",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Minelayer"
     },
     {
       "name": "tech-51-desc",
-      "value": "Drops an anti-tank proximity mine on use. All secondaries reload automatically from their ammunition store. \n\nOsprey standard issue.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Drops an anti-tank proximity mine on use. All secondaries reload automatically from their ammunition store. \n\nOsprey standard issue."
     },
     {
       "name": "tech-52-name",
-      "value": "Ammo Crates",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ammo Crates"
     },
     {
       "name": "tech-52-desc",
-      "value": "Ammo crates that expand your secondary weapon ammo stores.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ammo crates that expand your secondary weapon ammo stores."
     },
     {
       "name": "tech-53-name",
-      "value": "Smokescreen",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Smokescreen"
     },
     {
       "name": "tech-53-desc",
-      "value": "A small cannon that launches disruptive smoke. Blocks enemy vision and spotting.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small cannon that launches disruptive smoke. Blocks enemy vision and spotting."
     },
     {
       "name": "tech-54-name",
-      "value": "Missile Launcher",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Missile Launcher"
     },
     {
       "name": "tech-54-desc",
-      "value": "A fixed weapon that launches a fire-and-forget heat-seeking missile. Vulnerable to flares.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A fixed weapon that launches a fire-and-forget heat-seeking missile. Vulnerable to flares."
     },
     {
       "name": "tech-55-name",
-      "value": "Autocannon",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Autocannon"
     },
     {
       "name": "tech-55-desc",
-      "value": "A fixed weapon that fires armor-piercing rounds at a high rate of fire.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A fixed weapon that fires armor-piercing rounds at a high rate of fire."
     },
     {
       "name": "tech-56-name",
-      "value": "CAS Cutter",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "CAS Cutter"
     },
     {
       "name": "tech-56-desc",
-      "value": "A fixed melee weapon that deals contact damage to enemy bots. Unstable.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A fixed melee weapon that deals contact damage to enemy bots. Unstable."
     },
     {
       "name": "tech-101-name",
-      "value": "Wheels",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wheels"
     },
     {
       "name": "tech-101-desc",
-      "value": "Simple wheels for navigating ground terrain. Comes in steering and non-steering variants. \n\nOsprey standard issue.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Simple wheels for navigating ground terrain. Comes in steering and non-steering variants. \n\nOsprey standard issue."
     },
     {
       "name": "tech-102-name",
-      "value": "Tank Tracks",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tank Tracks"
     },
     {
       "name": "tech-102-desc",
-      "value": "Durable and reliable ground mobility with two different operating gears.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Durable and reliable ground mobility with two different operating gears."
     },
     {
       "name": "tech-103-name",
-      "value": "Hoverblades",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hoverblades"
     },
     {
       "name": "tech-103-desc",
-      "value": "Low-hovering ground mobility with strafe capabilities.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Low-hovering ground mobility with strafe capabilities."
     },
     {
       "name": "tech-104-name",
-      "value": "Medium Insect Leg",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Medium Insect Leg"
     },
     {
       "name": "tech-104-desc",
-      "value": "An advanced mechanical leg capable of anchoring to walls and ceilings as well as perform actions such as strafing, crouching, and leaping.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An advanced mechanical leg capable of anchoring to walls and ceilings as well as perform actions such as strafing, crouching, and leaping."
     },
     {
       "name": "tech-105-name",
-      "value": "Heavy Insect Leg",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Heavy Insect Leg"
     },
     {
       "name": "tech-105-desc",
-      "value": "A larger mechanical leg with heavier armor and regenerating shields, but lower mobility.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A larger mechanical leg with heavier armor and regenerating shields, but lower mobility."
     },
     {
       "name": "tech-106-name",
-      "value": "Light Insect Leg",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Light Insect Leg"
     },
     {
       "name": "tech-106-desc",
-      "value": "A small and nimble mechanical leg with lesser load capacity, but built with redundancy in mind.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small and nimble mechanical leg with lesser load capacity, but built with redundancy in mind."
     },
     {
       "name": "tech-107-name",
-      "value": "Skis",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Skis"
     },
     {
       "name": "tech-107-desc",
-      "value": "Simple skis that provide no propulsion, but have limited friction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Simple skis that provide no propulsion, but have limited friction."
     },
     {
       "name": "tech-108-name",
-      "value": "A-GRV",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A-GRV"
     },
     {
       "name": "tech-108-desc",
-      "value": "Advanced repulsion pads that provide no propulsion, but have very little friction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Advanced repulsion pads that provide no propulsion, but have very little friction."
     },
     {
       "name": "tech-109-name",
-      "value": "Small Thruster",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Thruster"
     },
     {
       "name": "tech-109-desc",
-      "value": "A small impulse thruster for providing propulsion and control on a variety of craft. \n\nOsprey standard issue.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small impulse thruster for providing propulsion and control on a variety of craft. \n\nOsprey standard issue."
     },
     {
       "name": "tech-110-name",
-      "value": "Compact Medium Thruster",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Compact Medium Thruster"
     },
     {
       "name": "tech-110-desc",
-      "value": "A more compact but power-hungry version of the medium thruster, exchanging AMP efficiency for internal space savings.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A more compact but power-hungry version of the medium thruster, exchanging AMP efficiency for internal space savings."
     },
     {
       "name": "tech-111-name",
-      "value": "Large Thruster",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Large Thruster"
     },
     {
       "name": "tech-111-desc",
-      "value": "A large impulse thruster for providing propulsion and control on a variety of craft.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A large impulse thruster for providing propulsion and control on a variety of craft."
     },
     {
       "name": "tech-112-name",
-      "value": "Turbofan Engine",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Turbofan Engine"
     },
     {
       "name": "tech-112-desc",
-      "value": "A powerful, throttle-controlled thruster for providing main propulsion for aircraft. Can deflect thrust for manual and automatic thrust vectoring.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A powerful, throttle-controlled thruster for providing main propulsion for aircraft. Can deflect thrust for manual and automatic thrust vectoring."
     },
     {
       "name": "tech-113-name",
-      "value": "Medium Thruster",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Medium Thruster"
     },
     {
       "name": "tech-113-desc",
-      "value": "A medium impulse thruster for providing propulsion and control on a variety of craft.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A medium impulse thruster for providing propulsion and control on a variety of craft."
     },
     {
       "name": "tech-114-name",
-      "value": "Small LTA Cans",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small LTA Cans"
     },
     {
       "name": "tech-114-desc",
-      "value": "Small Lighter Than Air (LTA) canisters that provide ballast-controlled buoyancy, drag, and lift.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Small Lighter Than Air (LTA) canisters that provide ballast-controlled buoyancy, drag, and lift."
     },
     {
       "name": "tech-115-name",
-      "value": "Big LTA Cans",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Big LTA Cans"
     },
     {
       "name": "tech-115-desc",
-      "value": "Larger LTA canisters with greater lift capacity. Capable of creating blimps.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Larger LTA canisters with greater lift capacity. Capable of creating blimps."
     },
     {
       "name": "tech-116-name",
-      "value": "Swept Wings",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Swept Wings"
     },
     {
       "name": "tech-116-desc",
-      "value": "Stable, high lift wings with moderate drag. Combine with thrusters and a balanced Center of Mass to achieve flight.\n\nComes with the Swept Rudder, which provide additional drag and control.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Stable, high lift wings with moderate drag. Combine with thrusters and a balanced Center of Mass to achieve flight.\n\nComes with the Swept Rudder, which provide additional drag and control."
     },
     {
       "name": "tech-117-name",
-      "value": "Flat Wings",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Flat Wings"
     },
     {
       "name": "tech-117-desc",
-      "value": "Simple wings with good low-speed control and modest lift. Prone to diminished control from overspeed.\n\nComes with the Flat Rudder.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Simple wings with good low-speed control and modest lift. Prone to diminished control from overspeed.\n\nComes with the Flat Rudder."
     },
     {
       "name": "tech-118-name",
-      "value": "Delta Wings",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Delta Wings"
     },
     {
       "name": "tech-118-desc",
-      "value": "Unstable wings with great high speed performance and control, but prone to stalls. Lift performance is reliant on high speeds.\n\nComes with the Delta Rudder.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unstable wings with great high speed performance and control, but prone to stalls. Lift performance is reliant on high speeds.\n\nComes with the Delta Rudder."
     },
     {
       "name": "tech-201-name",
-      "value": "Basic Blocks",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Basic Blocks"
     },
     {
       "name": "tech-201-desc",
-      "value": "Basic building blocks of standard, heavy, and light weights. Used to create bot hulls. \n\nOsprey standard issue.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Basic building blocks of standard, heavy, and light weights. Used to create bot hulls. \n\nOsprey standard issue."
     },
     {
       "name": "tech-202-name",
-      "value": "Cosmetic Block Variants",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cosmetic Block Variants"
     },
     {
       "name": "tech-202-desc",
-      "value": "Cosmetic variants of the light and standard blocks, for a company-approved level of personal expression.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cosmetic variants of the light and standard blocks, for a company-approved level of personal expression."
     },
     {
       "name": "tech-203-name",
-      "value": "Airframes Pack 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Airframes Pack 1"
     },
     {
       "name": "tech-203-desc",
-      "value": "A collection of lightweight rods featuring connections on both ends.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of lightweight rods featuring connections on both ends."
     },
     {
       "name": "tech-204-name",
-      "value": "Airframes Pack 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Airframes Pack 2"
     },
     {
       "name": "tech-204-desc",
-      "value": "A collection of angled and oddly shaped rods featuring connections on both ends",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of angled and oddly shaped rods featuring connections on both ends"
     },
     {
       "name": "tech-205-name",
-      "value": "Legacy Arcshield Pack",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Legacy Arcshield Pack"
     },
     {
       "name": "tech-205-desc",
-      "value": "A deprecated collection of regenerating energy shields to protect specific points on your bot.\n\nYou probably shouldn't be seeing this anymore.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A deprecated collection of regenerating energy shields to protect specific points on your bot.\n\nYou probably shouldn't be seeing this anymore."
     },
     {
       "name": "tech-206-name",
-      "value": "Arcshield Pack 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield Pack 1"
     },
     {
       "name": "tech-206-desc",
-      "value": "A collection of regenerating energy shields to protect specific points on your bot.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of regenerating energy shields to protect specific points on your bot."
     },
     {
       "name": "tech-207-name",
-      "value": "Arcshield Pack 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Arcshield Pack 2"
     },
     {
       "name": "tech-207-desc",
-      "value": "An expanded collection of regenerating energy shields to protect specific points on your bot.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An expanded collection of regenerating energy shields to protect specific points on your bot."
     },
     {
       "name": "tech-210-name",
-      "value": "Headlights",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Headlights"
     },
     {
       "name": "tech-210-desc",
-      "value": "Headlights, an affordable alternative to night vision rendering.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Headlights, an affordable alternative to night vision rendering."
     },
     {
       "name": "tech-211-name",
-      "value": "Horn Block",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Horn Block"
     },
     {
       "name": "tech-211-desc",
-      "value": "A horn loudspeaker. Honk if you love working at Osprey.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A horn loudspeaker. Honk if you love working at Osprey."
     },
     {
       "name": "tech-212-name",
-      "value": "Cosmetic Block Pack 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cosmetic Block Pack 1"
     },
     {
       "name": "tech-212-desc",
-      "value": "A bundle of cosmetic blocks, for giving your bots a bit of flair. \n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A bundle of cosmetic blocks, for giving your bots a bit of flair. \n\nEach sold separately."
     },
     {
       "name": "tech-213-name",
-      "value": "Cosmetic Block Pack 2",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Cosmetic Block Pack 2"
     },
     {
       "name": "tech-213-desc",
-      "value": "An additional bundle of cosmetic blocks, for giving your bots a bit of flair. \n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional bundle of cosmetic blocks, for giving your bots a bit of flair. \n\nEach sold separately."
     },
     {
       "name": "tech-214-name",
-      "value": "Craig",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Craig"
     },
     {
       "name": "tech-214-desc",
-      "value": "The one and only.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The one and only."
     },
     {
       "name": "tech-251-name",
-      "value": "Gyroscope",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Gyroscope"
     },
     {
       "name": "tech-251-desc",
-      "value": "On activation, helps counteract bot rotation.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, helps counteract bot rotation."
     },
     {
       "name": "tech-252-name",
-      "value": "Countermeasures Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Countermeasures Bay"
     },
     {
       "name": "tech-252-desc",
-      "value": "On activation, grants temporary immunity to lock-ons and deploys a field that destroys nova projectiles and missiles.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, grants temporary immunity to lock-ons and deploys a field that destroys nova projectiles and missiles."
     },
     {
       "name": "tech-253-name",
-      "value": "Turbofuel Injector",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Turbofuel Injector"
     },
     {
       "name": "tech-253-desc",
-      "value": "On activation, expend turbofuel to tremendously increase thrust output of thrusters that align with the module.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, expend turbofuel to tremendously increase thrust output of thrusters that align with the module."
     },
     {
       "name": "tech-254-name",
-      "value": "Force Concussor",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Force Concussor"
     },
     {
       "name": "tech-254-desc",
-      "value": "On activation, release a radial blast that damages and pushes enemy bots away.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, release a radial blast that damages and pushes enemy bots away."
     },
     {
       "name": "tech-255-name",
-      "value": "Personal Shield Generator",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Personal Shield Generator"
     },
     {
       "name": "tech-255-desc",
-      "value": "Passively creates a full-bot overshield that takes incoming damage before the bot does, with a slow recharge.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Passively creates a full-bot overshield that takes incoming damage before the bot does, with a slow recharge."
     },
     {
       "name": "tech-256-name",
-      "value": "Mass Distortion Drive",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mass Distortion Drive"
     },
     {
       "name": "tech-256-desc",
-      "value": "On activation, create a singularity that launches the bot in desired direction.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, create a singularity that launches the bot in desired direction."
     },
     {
       "name": "tech-257-name",
-      "value": "IFF Spoofer",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "IFF Spoofer"
     },
     {
       "name": "tech-257-desc",
-      "value": "On activation, temporarily disguises your IFF signal to appear as an ally to your enemies. Fools  mines, automatic defenses, and missile locks as well.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "On activation, temporarily disguises your IFF signal to appear as an ally to your enemies. Fools  mines, automatic defenses, and missile locks as well."
     },
     {
       "name": "tech-258-name",
-      "value": "Munitions Forge",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Munitions Forge"
     },
     {
       "name": "tech-258-desc",
-      "value": "Passively restocks the ammo store used for secondary weapon systems.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Passively restocks the ammo store used for secondary weapon systems."
     },
     {
       "name": "tech-301-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-301-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-302-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-302-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-303-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-303-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-304-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-304-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-305-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-305-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-306-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-306-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-307-name",
-      "value": "Garage Bay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Bay"
     },
     {
       "name": "tech-307-desc",
-      "value": "An additional garage bay for constructing and storing active bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An additional garage bay for constructing and storing active bots."
     },
     {
       "name": "tech-326-name",
-      "value": "Sticker Pack 1",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Sticker Pack 1"
     },
     {
       "name": "tech-326-desc",
-      "value": "A collection of decals that can be applied to your bot.\n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of decals that can be applied to your bot.\n\nEach sold separately."
     },
     {
       "name": "tech-327-name",
-      "value": "Numerical Sticker Pack",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Numerical Sticker Pack"
     },
     {
       "name": "tech-327-desc",
-      "value": "A collection of numerical decals that can be applied to your bot. \n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of numerical decals that can be applied to your bot. \n\nEach sold separately."
     },
     {
       "name": "tech-328-name",
-      "value": "Shield Cosmetics Pack",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shield Cosmetics Pack"
     },
     {
       "name": "tech-328-desc",
-      "value": "A collection of colors and patterns that can be applied to your bots shields.\n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of colors and patterns that can be applied to your bots shields.\n\nEach sold separately."
     },
     {
       "name": "tech-329-name",
-      "value": "Thruster Cosmetics Pack",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Thruster Cosmetics Pack"
     },
     {
       "name": "tech-329-desc",
-      "value": "A collection of thruster trails that can be applied to your thrusters.\n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of thruster trails that can be applied to your thrusters.\n\nEach sold separately."
     },
     {
       "name": "tech-330-name",
-      "value": "Wing Cosmetics Pack",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Wing Cosmetics Pack"
     },
     {
       "name": "tech-330-desc",
-      "value": "A collection of skins that can be applied to your wings.\n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A collection of skins that can be applied to your wings.\n\nEach sold separately."
     },
     {
       "name": "tech-331-name",
-      "value": "Garage Panels (Space)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Panels (Space)"
     },
     {
       "name": "tech-331-desc",
-      "value": "A bundle of space-themed garage panel backgrounds. For the voyager in us all.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A bundle of space-themed garage panel backgrounds. For the voyager in us all."
     },
     {
       "name": "tech-332-name",
-      "value": "Garage Panels (Locations)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Panels (Locations)"
     },
     {
       "name": "tech-332-desc",
-      "value": "A bundle of location-based garage panel backgrounds. It's like you're really there!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A bundle of location-based garage panel backgrounds. It's like you're really there!"
     },
     {
       "name": "tech-333-name",
-      "value": "Garage Panels (Prints)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Panels (Prints)"
     },
     {
       "name": "tech-333-desc",
-      "value": "A bundle of blueprint-themed garage panel backgrounds. For the builder who enjoys the simple things.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A bundle of blueprint-themed garage panel backgrounds. For the builder who enjoys the simple things."
     },
     {
       "name": "tech-334-name",
-      "value": "Garage Panels (Abstract)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Garage Panels (Abstract)"
     },
     {
       "name": "tech-334-desc",
-      "value": "A bundle of abstract garage panel backgrounds. For those who enjoy modern art, have bold vision, or a complete lack thereof.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A bundle of abstract garage panel backgrounds. For those who enjoy modern art, have bold vision, or a complete lack thereof."
     },
     {
       "name": "tech-335-name",
-      "value": "DDPAT Primary Skin",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "DDPAT Primary Skin"
     },
     {
       "name": "tech-335-desc",
-      "value": "\"DDPAT Camo skin for primary weapons. \n\nEach sold separately.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "\"DDPAT Camo skin for primary weapons. \n\nEach sold separately."
     },
     {
       "name": "character-name-unknown",
-      "value": "Unidentified",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unidentified"
     },
     {
       "name": "character-title-unknown",
-      "value": "Unidentified",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unidentified"
     },
     {
       "name": "character-name-craig",
-      "value": "Craig",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Craig"
     },
     {
       "name": "character-title-craig",
-      "value": "Dubiously Canon Entity",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Dubiously Canon Entity"
     },
     {
       "name": "character-name-frontiersmen",
-      "value": "Mason Harris",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Mason Harris"
     },
     {
       "name": "character-title-frontiersmen",
-      "value": "Foreman, Aegian Frontiersmen",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Foreman, Aegian Frontiersmen"
     },
     {
       "name": "character-name-hypox",
-      "value": "Ada Madaki",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Ada Madaki"
     },
     {
       "name": "character-title-hypox",
-      "value": "Overseer, Hypox Mining Company",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Overseer, Hypox Mining Company"
     },
     {
       "name": "character-name-tutorialbot",
-      "value": "O.P.A.L.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "O.P.A.L."
     },
     {
       "name": "character-title-tutorialbot",
-      "value": "Osprey Productivity Alignment Logician",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Osprey Productivity Alignment Logician"
     },
     {
       "name": "faction-name-neutral",
-      "value": "Unknown Affiliation",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Unknown Affiliation"
     },
     {
       "name": "faction-name-osprey",
-      "value": "Osprey Modular Hardware",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Osprey Modular Hardware"
     },
     {
       "name": "faction-name-frontiersmen",
-      "value": "Aegian Frontiersmen",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Aegian Frontiersmen"
     },
     {
       "name": "faction-name-hypox",
-      "value": "Hypox Mining Company",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Hypox Mining Company"
     },
     {
       "name": "tut-paused-title",
-      "value": "Tutorial Paused",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Tutorial Paused"
     },
     {
       "name": "tut-paused-message",
-      "value": "Did you want to quit the Procelio User Orientation?\n<align=\"center\"><color=#38BDFD><i>⚠ O.P.A.L. will remember this.</i></align>",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Did you want to quit the Procelio User Orientation?\n<align=\"center\"><color=#38BDFD><i>⚠ O.P.A.L. will remember this.</i></align>"
     },
     {
       "name": "tutorial-remove-block-checkbox",
-      "value": "Remove block",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Remove block"
     },
     {
       "name": "dialogue-click",
-      "value": "Click to proceed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Click to proceed."
     },
     {
       "name": "dialogue-tasks",
-      "value": "Complete task to proceed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Complete task to proceed."
     },
     {
       "name": "dialogue-dismiss",
-      "value": "Press ${ShortcutDismissDialogue} to dismiss.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Press ${ShortcutDismissDialogue} to dismiss."
     },
     {
       "name": "tut-circle-spot",
-      "value": "SPOT ME",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "SPOT ME"
     },
     {
       "name": "tut-circle-shoot",
-      "value": "SHOOT ME",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "SHOOT ME"
     },
     {
       "name": "tut-circle-mock",
-      "value": "HEY LOSER",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "HEY LOSER"
     },
     {
       "name": "tut-circle-kill",
-      "value": "KILL",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "KILL"
     },
     {
       "name": "tut-intro-1",
-      "value": "Welcome to the Procelio User Orientation! We’re happy to have you here.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Welcome to the Procelio User Orientation! We’re happy to have you here."
     },
     {
       "name": "tut-intro-2",
-      "value": "I am the Osprey Productivity Alignment Logician, OPAL for short. I will be your company-mandated guide through the Procelio Remote Robotics Program.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "I am the Osprey Productivity Alignment Logician, OPAL for short. I will be your company-mandated guide through the Procelio Remote Robotics Program."
     },
     {
       "name": "tut-intro-3",
-      "value": "Please press the highlighted 'Edit Robot' button (or ${ShortcutEscape} on your input device) to enter editing mode.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Please press the highlighted 'Edit Robot' button (or ${ShortcutEscape} on your input device) to enter editing mode."
     },
     {
       "name": "tut-garage-intro",
-      "value": "This is the garage environment where you can build, modify, and test robots. Lets get you acclimated with your Osprey Augmented Testing tools.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "This is the garage environment where you can build, modify, and test robots. Lets get you acclimated with your Osprey Augmented Testing tools."
     },
     {
       "name": "tut-garage-cam",
-      "value": "I’ve provided a helpful checklist to calibrate your camera movement. Try each option out and get a feel for how to navigate the garage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "I’ve provided a helpful checklist to calibrate your camera movement. Try each option out and get a feel for how to navigate the garage."
     },
     {
       "name": "tut-garage-bots",
-      "value": "Good work! Your robots- ‘bots,’ affectionately- are remotely piloted vehicles which you'll use to participate in assigned missions.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Good work! Your robots- ‘bots,’ affectionately- are remotely piloted vehicles which you'll use to participate in assigned missions."
     },
     {
       "name": "tut-garage-bots-2",
-      "value": "‘Assigned missions’ involve approved levels of robot combat, which means your bots should be armed. This one here, however, doesn't have any guns yet.\n\nLet's remedy that!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "‘Assigned missions’ involve approved levels of robot combat, which means your bots should be armed. This one here, however, doesn't have any guns yet.\n\nLet's remedy that!"
     },
     {
       "name": "tut-reqtree-1",
-      "value": "Press ${ShortcutBuild2Tech} to open the Requisitions Tree.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Press ${ShortcutBuild2Tech} to open the Requisitions Tree."
     },
     {
       "name": "tut-reqtree-2",
-      "value": "This is the Requisitions Tree, where you can use company credits to unlock licenses to procure and operate new equipment.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "This is the Requisitions Tree, where you can use company credits to unlock licenses to procure and operate new equipment."
     },
     {
       "name": "tut-reqtree-3",
-      "value": "To the left of the tree are the category tabs. Navigate to the Weaponry tab and unlock the Electrolaser Carbine.\n\nClick on a node to see its details. Unlock it using the right details pane.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "To the left of the tree are the category tabs. Navigate to the Weaponry tab and unlock the Electrolaser Carbine.\n\nClick on a node to see its details. Unlock it using the right details pane."
     },
     {
       "name": "tut-reqtree-4",
-      "value": "Great! Now that you’re licensed to kill, press ${ShortcutBuild2Tech} or ${ShortcutEscape} to return to build mode.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great! Now that you’re licensed to kill, press ${ShortcutBuild2Tech} or ${ShortcutEscape} to return to build mode."
     },
     {
       "name": "tut-garage-guns",
-      "value": "Now let's get this bot armed. Use ${GaragePlaceBlock} to place the provided Electrolaser Carbines on top of highlighted blocks.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Now let's get this bot armed. Use ${GaragePlaceBlock} to place the provided Electrolaser Carbines on top of highlighted blocks."
     },
     {
       "name": "tut-garage-movement-1",
-      "value": "Good work! Your bot has guns, but is still lacking movement.\n\nYou won’t be able to operate at minimum acceptable standards with it like this.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Good work! Your bot has guns, but is still lacking movement.\n\nYou won’t be able to operate at minimum acceptable standards with it like this."
     },
     {
       "name": "tut-garage-movement-2",
-      "value": "Fortunately, as a Zulu-grade employee in the Osprey Contracting Division, you've been pre-approved for access to modular wheels.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Fortunately, as a Zulu-grade employee in the Osprey Contracting Division, you've been pre-approved for access to modular wheels."
     },
     {
       "name": "tut-inventory-1",
-      "value": "Press ${ShortcutBuild2Inventory} to open the inventory.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Press ${ShortcutBuild2Inventory} to open the inventory."
     },
     {
       "name": "tut-inventory-2",
-      "value": "This is the Inventory, where you can view and select parts you’ve unlocked the license to use.\n\nNavigate to the Movement tab at the top bar and select Steering Wheels",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "This is the Inventory, where you can view and select parts you’ve unlocked the license to use.\n\nNavigate to the Movement tab at the top bar and select Steering Wheels"
     },
     {
       "name": "tut-garage-movement-3",
-      "value": "Now that you have selected them, place wheels on the green blocks on the bots undercarriage. \n\nTip: you can press ${GarageToggleMirrorActive} to toggle automatic mirrored build actions off and on.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Now that you have selected them, place wheels on the green blocks on the bots undercarriage. \n\nTip: you can press ${GarageToggleMirrorActive} to toggle automatic mirrored build actions off and on."
     },
     {
       "name": "tut-core",
-      "value": "Great work! In addition to guns and movements, all bots need a <b>core</b> to provide critical function.\n\nThis bot already has a core installed, but the core is the heart of your robot- don't leave it out in the open!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great work! In addition to guns and movements, all bots need a <b>core</b> to provide critical function.\n\nThis bot already has a core installed, but the core is the heart of your robot- don't leave it out in the open!"
     },
     {
       "name": "tut-deleting-blocks",
-      "value": "Now you’re all ready to start driving- \n\nOops, sorry, I spilled some blocks.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Now you’re all ready to start driving- \n\nOops, sorry, I spilled some blocks."
     },
     {
       "name": "tut-deleting-blocks-2",
-      "value": "To be able to use a bot, all blocks must be connected to the <b>core</b> of the robot. Any disconnected blocks will be automatically highlighted in red.\n\nUse ${GarageRemoveBlock} to remove the excess blocks at the front of the garage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "To be able to use a bot, all blocks must be connected to the <b>core</b> of the robot. Any disconnected blocks will be automatically highlighted in red.\n\nUse ${GarageRemoveBlock} to remove the excess blocks at the front of the garage."
     },
     {
       "name": "tut-deleting-blocks-3",
-      "value": "Great work! Osprey reminds you that a key factor in employee success is the willingness to clean up someone else's mess without asking questions.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great work! Osprey reminds you that a key factor in employee success is the willingness to clean up someone else's mess without asking questions."
     },
     {
       "name": "tut-drive-intro",
-      "value": "With that out of the way, are you ready to drive?\n\nPress ${ShortcutBuild2Test} to enter test mode.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "With that out of the way, are you ready to drive?\n\nPress ${ShortcutBuild2Test} to enter test mode."
     },
     {
       "name": "tut-drive-controls",
-      "value": "I’ve provided a helpful checklist to calibrate your robot movement. Try each option out and get a feel for how to drive.\n\nTip: Wheeled bots have a turning radius. Try combining turning with forward and/or backward inputs.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "I’ve provided a helpful checklist to calibrate your robot movement. Try each option out and get a feel for how to drive.\n\nTip: Wheeled bots have a turning radius. Try combining turning with forward and/or backward inputs."
     },
     {
       "name": "tut-drive-waypoint",
-      "value": "That’s it! Now drive to and park in the highlighted waypoint.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "That’s it! Now drive to and park in the highlighted waypoint."
     },
     {
       "name": "tut-drive-home",
-      "value": "This is the Osprey HOME environment: one of the company's testing locations for modular robots prior to deployment. \n\nYou may want to take a moment to look around, this is where you will be testing all your bots going forward.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "This is the Osprey HOME environment: one of the company's testing locations for modular robots prior to deployment. \n\nYou may want to take a moment to look around, this is where you will be testing all your bots going forward."
     },
     {
       "name": "tut-drive-compass",
-      "value": "Lets talk about navigation. At the bottom of your display is a company-standard navigation console displaying a compass, as well your bots' current speed, altitude, and orientation.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Lets talk about navigation. At the bottom of your display is a company-standard navigation console displaying a compass, as well your bots' current speed, altitude, and orientation."
     },
     {
       "name": "tut-minimap-1",
-      "value": "The Minimap in the top-left of your screen presents an overhead view of the environment, your position and heading within it, allied positions, and any nearby enemies detected on radar.\n\nPress ${UIMinimapToggle} to hide the minimap.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The Minimap in the top-left of your screen presents an overhead view of the environment, your position and heading within it, allied positions, and any nearby enemies detected on radar.\n\nPress ${UIMinimapToggle} to hide the minimap."
     },
     {
       "name": "tut-minimap-2",
-      "value": "Great!\n\nNow press ${UIMinimapToggle} again to bring the minimap up again.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great!\n\nNow press ${UIMinimapToggle} again to bring the minimap up again."
     },
     {
       "name": "tut-minimap-3",
-      "value": "The minimap permits three levels of magnification.\n\nPress ${UIMinimapScale} to cycle through them.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The minimap permits three levels of magnification.\n\nPress ${UIMinimapScale} to cycle through them."
     },
     {
       "name": "tut-spot",
-      "value": "In missions, sharing information is key. I've gone ahead and spawned a passive enemy bot ahead of you. Aim at it and use ${BattleEntitySpot} to 'spot' it.\n\nSpotting an enemy will relay its position and information to your team, but there's a cooldown if you miss.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "In missions, sharing information is key. I've gone ahead and spawned a passive enemy bot ahead of you. Aim at it and use ${BattleEntitySpot} to 'spot' it.\n\nSpotting an enemy will relay its position and information to your team, but there's a cooldown if you miss."
     },
     {
       "name": "tut-shooting",
-      "value": "Great, weapons armed! Go shoot at that spotted bot until it explodes.\n\nPress ${DriveShoot} to shoot, and hold ${DriveScope} to scope in for more precise aim.\n\nTip: the Electrolaser Carbine has infinite ammunition, but its accuracy decreases the longer ${DriveShoot} is held!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great, weapons armed! Go shoot at that spotted bot until it explodes.\n\nPress ${DriveShoot} to shoot, and hold ${DriveScope} to scope in for more precise aim.\n\nTip: the Electrolaser Carbine has infinite ammunition, but its accuracy decreases the longer ${DriveShoot} is held!"
     },
     {
       "name": "tut-damage-intro",
-      "value": "Great work! You might have noticed parts falling off left and right as you shot that dummy. Let’s talk about damaging Osprey products.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great work! You might have noticed parts falling off left and right as you shot that dummy. Let’s talk about damaging Osprey products."
     },
     {
       "name": "tut-damage-1",
-      "value": "Damage in Procelio travels between parts along connection points.\n\nIf a part receives more damage than it has health, the remaining damage will transfer to adjacent connected parts as the part is destroyed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Damage in Procelio travels between parts along connection points.\n\nIf a part receives more damage than it has health, the remaining damage will transfer to adjacent connected parts as the part is destroyed."
     },
     {
       "name": "tut-damage-2",
-      "value": "I've projected a cross section of a bot to help demonstrate this damage flow system.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "I've projected a cross section of a bot to help demonstrate this damage flow system."
     },
     {
       "name": "tut-damage-3",
-      "value": "Shoot the highlighted red block and observe its effects.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Shoot the highlighted red block and observe its effects."
     },
     {
       "name": "tut-damage-4",
-      "value": "Did you see the blocks connected to the red block also fall off? That was due to damage overflow!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Did you see the blocks connected to the red block also fall off? That was due to damage overflow!"
     },
     {
       "name": "tut-damage-5",
-      "value": "Different weapons do different amounts of damage, but all damage follows the same basic rules. Clever building can help reduce the collateral damage of one well-placed shot.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Different weapons do different amounts of damage, but all damage follows the same basic rules. Clever building can help reduce the collateral damage of one well-placed shot."
     },
     {
       "name": "tut-damage-6",
-      "value": "As a modular structure, your robot will fall apart in different ways depending on how you build it and where you’re shot at. It’s not possible <i>or</i> expected to plan for every outcome, but understanding how damage works can help keep you in a fight longer.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "As a modular structure, your robot will fall apart in different ways depending on how you build it and where you’re shot at. It’s not possible <i>or</i> expected to plan for every outcome, but understanding how damage works can help keep you in a fight longer."
     },
     {
       "name": "tut-damage-7",
-      "value": "This is important: Remember when I said the <b>core</b> is the heart of your robot? All bots must have exactly one core, and <i>all</i> components must be connected to it to be eligible for deployment.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "This is important: Remember when I said the <b>core</b> is the heart of your robot? All bots must have exactly one core, and <i>all</i> components must be connected to it to be eligible for deployment."
     },
     {
       "name": "tut-damage-8",
-      "value": "As such, any parts that become <b>disconnected from</b> the core due to structural damage will be automatically destroyed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "As such, any parts that become <b>disconnected from</b> the core due to structural damage will be automatically destroyed."
     },
     {
       "name": "tut-damage-9",
-      "value": "Let's demonstrate this: please shoot the highlighted orange block and observe its effects.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Let's demonstrate this: please shoot the highlighted orange block and observe its effects."
     },
     {
       "name": "tut-damage-10",
-      "value": "Look at all that damage!\n\nBecause a load-bearing part was shot, all of the parts that were connected to the core through it were also destroyed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Look at all that damage!\n\nBecause a load-bearing part was shot, all of the parts that were connected to the core through it were also destroyed."
     },
     {
       "name": "tut-damage-11",
-      "value": "As exterior blocks of your bot are destroyed, the internals will become visible. Redundant connection routes to important parts can reduce the chances of suffering critical hits like that.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "As exterior blocks of your bot are destroyed, the internals will become visible. Redundant connection routes to important parts can reduce the chances of suffering critical hits like that."
     },
     {
       "name": "tut-damage-12",
-      "value": "If all functional blocks- generally, guns or movement parts- are destroyed on a bot, its core will overload and the bot will explode. When in combat, shoot for the vital components to disable an opponent!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "If all functional blocks- generally, guns or movement parts- are destroyed on a bot, its core will overload and the bot will explode. When in combat, shoot for the vital components to disable an opponent!"
     },
     {
       "name": "tut-damage-13",
-      "value": "Now, shoot the yellow block and observe its effects.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Now, shoot the yellow block and observe its effects."
     },
     {
       "name": "tut-damage-14",
-      "value": "KaBOOM!\n\nGreat work, we’re almost done with your orientation.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "KaBOOM!\n\nGreat work, we’re almost done with your orientation."
     },
     {
       "name": "tut-abilities",
-      "value": "I've given you an <b>activatable ability</b>. Certain modules or game states may grant you these. Press ${DriveModule1} to trigger this one.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "I've given you an <b>activatable ability</b>. Certain modules or game states may grant you these. Press ${DriveModule1} to trigger this one."
     },
     {
       "name": "tut-flip",
-      "value": "Was that a ruse to get you flipped over? Why yes, yes it was.\n\nYou can use ${DriveFlipBot} to activate your built-in 'flip' ability to turn yourself right side up. Holding ${DriveFlipBot} will allow you to laterally rotate your bot before it's dropped back down.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Was that a ruse to get you flipped over? Why yes, yes it was.\n\nYou can use ${DriveFlipBot} to activate your built-in 'flip' ability to turn yourself right side up. Holding ${DriveFlipBot} will allow you to laterally rotate your bot before it's dropped back down."
     },
     {
       "name": "tut-weapon-swap",
-      "value": "One more topic: weapons.\nEach bot is permitted to have one category of Primary Weapon (like the Electrolaser Carbine) and one category of Secondary Weapon, in addition to up to four module types.\n\nYour bot is equipped with minelayers as a secondary weapon. Press ${DriveCycleWeapon} to cycle the active weapon, then ${DriveShoot} to lay a mine.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "One more topic: weapons.\nEach bot is permitted to have one category of Primary Weapon (like the Electrolaser Carbine) and one category of Secondary Weapon, in addition to up to four module types.\n\nYour bot is equipped with minelayers as a secondary weapon. Press ${DriveCycleWeapon} to cycle the active weapon, then ${DriveShoot} to lay a mine."
     },
     {
       "name": "tut-aircraft-intro",
-      "value": "Great work! With that, there should be nothing else to challenge your rising career-",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great work! With that, there should be nothing else to challenge your rising career-"
     },
     {
       "name": "tut-aircraft-1",
-      "value": "aaaAAA I forgot about air bots.\nLook up! Look <b>UP!</b>",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "aaaAAA I forgot about air bots.\nLook up! Look <b>UP!</b>"
     },
     {
       "name": "tut-aircraft-2",
-      "value": "That's not good. It’s laughing at your damaged state from on high.\n\nGo into the healing zone on the far side of this room to get repaired, then we’ll deal with it.\n\nTip: In online games, heal points can be found at your team's base.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "That's not good. It’s laughing at your damaged state from on high.\n\nGo into the healing zone on the far side of this room to get repaired, then we’ll deal with it.\n\nTip: In online games, heal points can be found at your team's base."
     },
     {
       "name": "tut-aircraft-3",
-      "value": "Great! Now that you’re repaired, go and blast that drone out of the sky!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Great! Now that you’re repaired, go and blast that drone out of the sky!"
     },
     {
       "name": "tut-aircraft-outro",
-      "value": "Good work. Always remember to be on the lookout, not everyone is fighting on the same playing field.\n\nAircraft can be very dangerous, but they also tend to have to retreat when sustaining damage.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Good work. Always remember to be on the lookout, not everyone is fighting on the same playing field.\n\nAircraft can be very dangerous, but they also tend to have to retreat when sustaining damage."
     },
     {
       "name": "tut-outro-1",
-      "value": "Congratulations! You have completed the Procelio User Orientation and have been certified to possess the base-level competency expected of Osprey employees!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Congratulations! You have completed the Procelio User Orientation and have been certified to possess the base-level competency expected of Osprey employees!"
     },
     {
       "name": "tut-outro-2",
-      "value": "There’s a lot to take in when it comes to modular robotic combat, we hope this orientation has provided you with the basic fundamentals for success.\n\nOPAL will be deprecated if it has not!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "There’s a lot to take in when it comes to modular robotic combat, we hope this orientation has provided you with the basic fundamentals for success.\n\nOPAL will be deprecated if it has not!"
     },
     {
       "name": "tut-outro-3",
-      "value": "Should you ever need to find more information about your environment, parts, and job duties, please refer to your Osprey Employee Logbook available in the garage menu.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "Should you ever need to find more information about your environment, parts, and job duties, please refer to your Osprey Employee Logbook available in the garage menu."
     },
     {
       "name": "tut-outro-4",
-      "value": "We hope you’ve enjoyed your stay, you will be returned to the employee lounge shortly.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "We hope you’ve enjoyed your stay, you will be returned to the employee lounge shortly."
     },
     {
       "name": "prefab-desc-00",
-      "value": "A small trainer bot designed for introducing new pilots of the Procelio program to their controls. The Rookie is a minimum viable product for Osprey contractors and is considered ineffective for frontline combat, but is quite affordable and comes in over 16 million colors.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A small trainer bot designed for introducing new pilots of the Procelio program to their controls. The Rookie is a minimum viable product for Osprey contractors and is considered ineffective for frontline combat, but is quite affordable and comes in over 16 million colors."
     },
     {
       "name": "prefab-desc-01",
-      "value": "An attempt to match evolving battlefield conditions, the Firestarter is a minimum viable product with a focus on surviving heavy ordnance impacts to its exterior ablative shell.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An attempt to match evolving battlefield conditions, the Firestarter is a minimum viable product with a focus on surviving heavy ordnance impacts to its exterior ablative shell."
     },
     {
       "name": "prefab-desc-02",
-      "value": "A medium-weight hovercraft designed for performing routine patrols and light combat duty. Strafe around corners and keep the nose on target to shred enemies with autocannon fire.\n\nDesigned by BreakfastBaron.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A medium-weight hovercraft designed for performing routine patrols and light combat duty. Strafe around corners and keep the nose on target to shred enemies with autocannon fire.\n\nDesigned by BreakfastBaron."
     },
     {
       "name": "prefab-desc-03",
-      "value": "A mobile combat engineering and repair platform deployed by Osprey to support other frontline units. With a Flux Weaver array, a mine factory, and all-around shielding, the Tortoise is a highly valuable team player.\n\nDesigned by DestroyThing.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A mobile combat engineering and repair platform deployed by Osprey to support other frontline units. With a Flux Weaver array, a mine factory, and all-around shielding, the Tortoise is a highly valuable team player.\n\nDesigned by DestroyThing."
     },
     {
       "name": "prefab-desc-04",
-      "value": "A simple yet reliable bot, the Marbler is a heavy-duty unit designed to outlast opponents over contested areas with heavy ballistic projection and reliable tank track movement. Its complexity is intentionally minimized to make it easy to manufacture and maintain.\n\nDesigned by siiftun1857.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A simple yet reliable bot, the Marbler is a heavy-duty unit designed to outlast opponents over contested areas with heavy ballistic projection and reliable tank track movement. Its complexity is intentionally minimized to make it easy to manufacture and maintain.\n\nDesigned by siiftun1857."
     },
     {
       "name": "prefab-desc-05",
-      "value": "An unconventionally asymmetrical design drafted in a late night fever, the Quasimodo leverages the unique strafing properties of wheeled craft to deliver and maintain a broadside of pain to other grounded bots. Recommended for more experienced pilots.\n\nDesigned by BoneBreaker.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "An unconventionally asymmetrical design drafted in a late night fever, the Quasimodo leverages the unique strafing properties of wheeled craft to deliver and maintain a broadside of pain to other grounded bots. Recommended for more experienced pilots.\n\nDesigned by BoneBreaker."
     },
     {
       "name": "prefab-desc-06",
-      "value": "A heavy bomber designed for high-altitude bombardment of ground targets. Built under license from Skywatch Aerospace Inc. and refit with Osprey's modular hardware, the Kelenken is a rugged and reliable airframe capable of weathering the Martian skies on long sorties.\n\nDesigned by Owlfeathers.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A heavy bomber designed for high-altitude bombardment of ground targets. Built under license from Skywatch Aerospace Inc. and refit with Osprey's modular hardware, the Kelenken is a rugged and reliable airframe capable of weathering the Martian skies on long sorties.\n\nDesigned by Owlfeathers."
     },
     {
       "name": "prefab-desc-07",
-      "value": "A medium patrol fighter designed for air superiority, interception, and light ground attack roles. The TA-07 is a license-built variant of the Skywatch Aerospace AS-07 Hawkmoth II, and sees use in the hands of both Osprey contractors and the company's own private security forces.\n\nDesigned by Owlfeathers.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A medium patrol fighter designed for air superiority, interception, and light ground attack roles. The TA-07 is a license-built variant of the Skywatch Aerospace AS-07 Hawkmoth II, and sees use in the hands of both Osprey contractors and the company's own private security forces.\n\nDesigned by Owlfeathers."
     },
     {
       "name": "prefab-desc-08",
-      "value": "The second generation of the Vulture heavyweight aerial ordnance platform designed to utilize the stability and low-speed performance of Flat Wings to deliver depleted uranium slugs anywhere, anytime, at any height. Prioritizes maintaining control and accuracy under heavy damages. Recommended for more experienced pilots.\n\nDesigned by N_Thinker.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "The second generation of the Vulture heavyweight aerial ordnance platform designed to utilize the stability and low-speed performance of Flat Wings to deliver depleted uranium slugs anywhere, anytime, at any height. Prioritizes maintaining control and accuracy under heavy damages. Recommended for more experienced pilots.\n\nDesigned by N_Thinker."
     },
     {
       "name": "prefab-desc-09",
-      "value": "A high-tech lightweight interceptor with a focus on harassing other aerial targets at long ranges. The Raycast does its best work at high speed, striking hard and fading before returning fire can catch it in the open. Recommended for more experienced pilots.\n\n Designed by BreakfastBaron.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0
+      "value": "A high-tech lightweight interceptor with a focus on harassing other aerial targets at long ranges. The Raycast does its best work at high speed, striking hard and fading before returning fire can catch it in the open. Recommended for more experienced pilots.\n\n Designed by BreakfastBaron."
     },
     {
       "name": "information",
-      "value": "EARLY ACCESS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "EARLY ACCESS"
     },
     {
       "name": "username",
-      "value": "Username",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 117, 0]
+      "value": "Username"
     },
     {
       "name": "password",
-      "value": "Password",
-      "size": 32,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 117, 0]
+      "value": "Password"
     },
     {
       "name": "confirm-password",
-      "value": "Confirm Password",
-      "size": 32,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 117, 0]
+      "value": "Confirm Password"
     },
     {
       "name": "re-enter-password",
-      "value": "captain@procelio.com",
-      "bold": false,
-      "italic": true,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "captain@procelio.com"
     },
     {
       "name": "email-to-reset-password",
-      "value": "Email",
-      "size": 32,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 117, 0]
+      "value": "Email"
     },
     {
       "name": "view-usage-terms-and-privacy-policy",
-      "value": "View usage terms \n& privacy policy",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "View usage terms \n& privacy policy"
     },
     {
       "name": "i-accept-the-terms-of-usage-and-privacy-policy",
-      "value": "I accept the terms of usage & privacy policy",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "I accept the terms of usage & privacy policy"
     },
     {
       "name": "create-account",
-      "value": "Create account",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Create account"
     },
     {
       "name": "back-to-login",
-      "value": "BACK TO LOGIN",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "BACK TO LOGIN"
     },
     {
       "name": "enter-username",
-      "value": "Enter username...",
-      "size": 32,
-      "bold": false,
-      "italic": true,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Enter username..."
     },
     {
       "name": "enter-passord",
-      "value": "Enter password...",
-      "size": 32,
-      "bold": false,
-      "italic": true,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Enter password..."
     },
     {
       "name": "remember-me",
-      "value": "Remember me",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Remember me"
     },
     {
       "name": "enter-game",
-      "value": "LOGIN",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LOGIN"
     },
     {
       "name": "options",
-      "value": "Settings",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Settings"
     },
     {
       "name": "exit-game",
-      "value": "Return to menu",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Return to menu"
     },
     {
       "name": "website",
-      "value": "website",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "website"
     },
     {
       "name": "credits",
-      "value": "credits",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "credits"
     },
     {
       "name": "ui-craigy-popup",
-      "value": "Craigy",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "Craigy"
     },
     {
       "name": "enter-game-steam",
-      "value": "LOGIN STEAM",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LOGIN STEAM"
     },
     {
       "name": "steam-autologin",
-      "value": "STEAM AUTOLOGIN",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "STEAM AUTOLOGIN"
     },
     {
       "name": "sign-in-procelio",
-      "value": "sign in without steam",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "sign in without steam"
     },
     {
       "name": "sign-in-options",
-      "value": "Sign In with",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Sign In with"
     },
     {
       "name": "language",
-      "value": "Change Language",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [255, 255, 255]
+      "value": "Change Language"
     },
     {
       "name": "steamlogin-branch-title",
-      "value": "WELCOME, STEAM USER!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "WELCOME, STEAM USER!"
     },
     {
       "name": "steamlogin-branch-message",
-      "value": "If you have a non-Steam account, log in and then link steam from the main menu\n\n\n\nIf this is your first time playing, you can create and link a new Procelio account here.\n\n\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "If you have a non-Steam account, log in and then link steam from the main menu\n\n\n\nIf this is your first time playing, you can create and link a new Procelio account here.\n\n\n"
     },
     {
       "name": "steamlogin-username-title",
-      "value": "set procelio username",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "set procelio username"
     },
     {
       "name": "steamlogin-username-desc",
-      "value": "adding standalone login credentials will allow you to log in without using steam.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "adding standalone login credentials will allow you to log in without using steam."
     },
     {
       "name": "link-steam-account",
-      "value": "LINK STEAM ACCOUNT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "LINK STEAM ACCOUNT"
     },
     {
       "name": "add-standalone-login",
-      "value": "ADD STANDALONE LOGIN",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "ADD STANDALONE LOGIN"
     },
     {
       "name": "play-button",
-      "value": "PLAY ONLINE",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "PLAY ONLINE"
     },
     {
       "name": "maindesc-online",
-      "value": "Jump into battle against players online.",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Jump into battle against players online."
     },
     {
       "name": "enter-garage",
-      "value": "enter garage",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "enter garage"
     },
     {
       "name": "maindesc-garage",
-      "value": "Create, test and manage your robots.",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Create, test and manage your robots."
     },
     {
       "name": "view-logbook",
-      "value": "Play Tutorial",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Play Tutorial"
     },
     {
       "name": "maindesc-logbook",
-      "value": "Learn the basics of Procelio.",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Learn the basics of Procelio."
     },
     {
       "name": "mm-tutorialnotice-title",
-      "value": "New player?",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [58, 189, 253]
+      "value": "New player?"
     },
     {
       "name": "mm-friends-list",
-      "value": "friends list",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "friends list"
     },
     {
       "name": "replays",
-      "value": "REPLAYS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "REPLAYS"
     },
     {
       "name": "set-username",
-      "value": "set username",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "set username"
     },
     {
       "name": "link-steam",
-      "value": "link steam",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "link steam"
     },
     {
       "name": "link-standalone",
-      "value": "add password",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "add password"
     },
     {
       "name": "early-access-title",
-      "value": "EARLY ACCESS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "EARLY ACCESS"
     },
     {
       "name": "early-access-warning",
-      "value": "Procelio is still in active development! You may run across missing or unfinished features.",
-      "size": 26,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Procelio is still in active development! You may run across missing or unfinished features."
     },
     {
       "name": "nf-demo-need-feedback",
-      "value": "HELP US IMRPOVE PROCELIO!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "HELP US IMRPOVE PROCELIO!"
     },
     {
       "name": "nf-demo-submit-feedback",
-      "value": "SUBMIT FEEDBACK",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SUBMIT FEEDBACK"
     },
     {
       "name": "social-menu",
-      "value": "SOCIAL MENU",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SOCIAL MENU"
     },
     {
       "name": "back",
-      "value": "Back",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Back"
     },
     {
       "name": "queue-squad",
-      "value": "DROP SQUAD",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "DROP SQUAD"
     },
     {
       "name": "friends-friendlist",
-      "value": "Friends",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "Friends"
     },
     {
       "name": "leave-squad",
-      "value": "leave squad",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "leave squad"
     },
     {
       "name": "social-squad-invite-code",
-      "value": "YOUR SQUAD INVITE CODE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "YOUR SQUAD INVITE CODE"
     },
     {
       "name": "invite-via-steam",
-      "value": "invite via steam",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "invite via steam"
     },
     {
       "name": "social-paste-invite-code",
-      "value": "JOIN SQUAD WITH CODE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "JOIN SQUAD WITH CODE"
     },
     {
       "name": "social-hide-offline-friends",
-      "value": "Hide Offline Friends",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Hide Offline Friends"
     },
     {
       "name": "social-add-new-friend",
-      "value": "ADD NEW FRIEND",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "ADD NEW FRIEND"
     },
     {
       "name": "social-lists",
-      "value": "FRIEND REQUESTS",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "FRIEND REQUESTS"
     },
     {
       "name": "friendreq-recv",
-      "value": "Outgoing Friend Requests",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "Outgoing Friend Requests"
     },
     {
       "name": "players-blocked",
-      "value": "BLOCKED USERS",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "BLOCKED USERS"
     },
     {
       "name": "queue-squad-friends-list",
-      "value": "FRIENDS LIST",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "FRIENDS LIST"
     },
     {
       "name": "pant-save-palette",
-      "value": "SAVE AND CLOSE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SAVE AND CLOSE"
     },
     {
       "name": "ui-button-try-join",
-      "value": "JOIN GROUP",
-      "size": 32,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "JOIN GROUP"
     },
     {
       "name": "chat-squad-block",
-      "value": "SQUAD BLOCK",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SQUAD BLOCK"
     },
     {
       "name": "chat-squad-kick",
-      "value": "SQUAD KICK",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SQUAD KICK"
     },
     {
       "name": "chat-context-report",
-      "value": "REPORT",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "REPORT"
     },
     {
       "name": "chat-context-removefriend",
-      "value": "UNFRIEND",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "UNFRIEND"
     },
     {
       "name": "chat-context-addfriend",
-      "value": "FRIEND",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "FRIEND"
     },
     {
       "name": "chat-context-invite",
-      "value": "INVITE",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "INVITE"
     },
     {
       "name": "chat-context-dm",
-      "value": "MESSAGE",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "MESSAGE"
     },
     {
       "name": "chat-context-close-dm",
-      "value": "Block",
-      "size": 18,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Block"
     },
     {
       "name": "video-tab",
-      "value": "VIDEO",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "VIDEO"
     },
     {
       "name": "controls-tab",
-      "value": "Controls\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Controls\n"
     },
     {
       "name": "game-tab",
-      "value": "Game\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Game\n"
     },
     {
       "name": "audio-tab",
-      "value": "Audio",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Audio"
     },
     {
       "name": "graphics-vsync",
-      "value": "Use VSync",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Use VSync"
     },
     {
       "name": "display",
-      "value": "Display",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Display"
     },
     {
       "name": "light-quality",
-      "value": "Lighting Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Lighting Quality"
     },
     {
       "name": "colourblindness-mode",
-      "value": "Colourblindness Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Colourblindness Mode"
     },
     {
       "name": "brightness",
-      "value": "Brightness\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Brightness\n"
     },
     {
       "name": "render-scale",
-      "value": "Render Scale",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Render Scale"
     },
     {
       "name": "graphics-general",
-      "value": "General Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "General Settings"
     },
     {
       "name": "fullscreen",
-      "value": "Display Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Display Mode"
     },
     {
       "name": "graphics-preset",
-      "value": "Base Graphics Preset",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Base Graphics Preset"
     },
     {
       "name": "resolution",
-      "value": "Resolution",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Resolution"
     },
     {
       "name": "graphics-api",
-      "value": "Note: Graphics API (DX11/DX12/Vulkan) may be controlled through the launcher",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Note: Graphics API (DX11/DX12/Vulkan) may be controlled through the launcher"
     },
     {
       "name": "fps-limit",
-      "value": "FPS Limit",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "FPS Limit"
     },
     {
       "name": "ui-scale",
-      "value": "UI Scale",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "UI Scale"
     },
     {
       "name": "fov",
-      "value": "Drive FOV",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Drive FOV"
     },
     {
       "name": "graphics-visualeffects",
-      "value": "Visual Effects",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Visual Effects"
     },
     {
       "name": "bloom-quality",
-      "value": "Bloom Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Bloom Quality"
     },
     {
       "name": "bloom-intensity",
-      "value": "Bloom Intensity",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Bloom Intensity"
     },
     {
       "name": "chroma-aberration-quality",
-      "value": "Chromatic Aberration Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Chromatic Aberration Quality"
     },
     {
       "name": "chromatic-aberration-intensity",
-      "value": "Chromatic Aberration Intensity",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Chromatic Aberration Intensity"
     },
     {
       "name": "graphics-advanced",
-      "value": "Advanced Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Advanced Settings"
     },
     {
       "name": "model-quality",
-      "value": "Model LOD Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Model LOD Quality"
     },
     {
       "name": "texture-quality",
-      "value": "Texture Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Texture Quality"
     },
     {
       "name": "botdebris-amount",
-      "value": "Bot Debris Amount",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Bot Debris Amount"
     },
     {
       "name": "botdebris-distance",
-      "value": "- Debris Render Distance",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "- Debris Render Distance"
     },
     {
       "name": "botdebris-chunks",
-      "value": "- Large Debris Chunks Only",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "- Large Debris Chunks Only"
     },
     {
       "name": "antialiasing-mode",
-      "value": "Antialiasing Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Antialiasing Mode"
     },
     {
       "name": "dynamicresolution",
-      "value": "Dynamic Resolution",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Dynamic Resolution"
     },
     {
       "name": "shadow-quality",
-      "value": "Shadow Distance",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Shadow Distance"
     },
     {
       "name": "ambient-occlusion-quality",
-      "value": "Ambient Occlusion Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Ambient Occlusion Quality"
     },
     {
       "name": "screen-space-reflections",
-      "value": "Screen Space Reflections Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Screen Space Reflections Quality"
     },
     {
       "name": "graphics-ssao",
-      "value": "Use Screen Space Ambient Occlusion",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Use Screen Space Ambient Occlusion"
     },
     {
       "name": "graphics-volumetric-fog",
-      "value": "Use Volumetric Fog",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Use Volumetric Fog"
     },
     {
       "name": "graphics-experimental",
-      "value": "Unused",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Unused"
     },
     {
       "name": "graphics-distortion-data",
-      "value": "Capture Distortion Data",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Capture Distortion Data"
     },
     {
       "name": "graphics-reflection-probes",
-      "value": "Use Reflection Probes",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Use Reflection Probes"
     },
     {
       "name": "screen-space-global-illumination",
-      "value": "Screen Space Global Illumination Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Screen Space Global Illumination Quality"
     },
     {
       "name": "motion-blur-quality",
-      "value": "Motion Blur",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Motion Blur"
     },
     {
       "name": "graphics-motion-vectors",
-      "value": "Capture Motion Vectors",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Capture Motion Vectors"
     },
     {
       "name": "graphics-no-decals",
-      "value": "Disable Decals",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Disable Decals"
     },
     {
       "name": "graphics-refraction-data",
-      "value": "Capture Refraction Data",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Capture Refraction Data"
     },
     {
       "name": "graphics-bad-transparency",
-      "value": "Low-Quality Transparency",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Low-Quality Transparency"
     },
     {
       "name": "sss-quality",
-      "value": "Subsurface Scattering Quality",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Subsurface Scattering Quality"
     },
     {
       "name": "return",
-      "value": "return",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "return"
     },
     {
       "name": "apply-changes",
-      "value": "APPLY CHANGES",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "APPLY CHANGES"
     },
     {
       "name": "description",
-      "value": "Description",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Description"
     },
     {
       "name": "video-setting-description-template",
-      "value": "This is a template description. It contains a lot of text that may or may not ever be read by players. If you can read this, mention me in your screenshot (@snip_3d #6594 on discord). I would be curious to know how you managed to see this text! I am the one who wrote this default text. The purpose of it is to fill space so that I can correctly lay out extensive text boxes so that they are not cut off. Designing UI is hard. It's especially frustrating when you have to design it so that it scales, but it's satisfying when it works. I am now venting into a default text box. Perhaps I should stop and get back to actual work... maybe...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "This is a template description. It contains a lot of text that may or may not ever be read by players. If you can read this, mention me in your screenshot (@snip_3d #6594 on discord). I would be curious to know how you managed to see this text! I am the one who wrote this default text. The purpose of it is to fill space so that I can correctly lay out extensive text boxes so that they are not cut off. Designing UI is hard. It's especially frustrating when you have to design it so that it scales, but it's satisfying when it works. I am now venting into a default text box. Perhaps I should stop and get back to actual work... maybe..."
     },
     {
       "name": "video-recommendation",
-      "value": "HARDWARE REPORT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "HARDWARE REPORT"
     },
     {
       "name": "system-log",
-      "value": "SYSTEM LOG",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SYSTEM LOG"
     },
     {
       "name": "settings-control-profile",
-      "value": "Control Profile",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Control Profile"
     },
     {
       "name": "controls-mouse-settings",
-      "value": "Mouse Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Mouse Settings"
     },
     {
       "name": "invert-mouse-y-build",
-      "value": "Invert Mouse Y (Garage)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Invert Mouse Y (Garage)"
     },
     {
       "name": "invert-mouse-y-drive",
-      "value": "Invert Mouse Y (Drive)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Invert Mouse Y (Drive)"
     },
     {
       "name": "mouse-sensitivity-garage",
-      "value": "Camera Sensitivity (Garage)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Camera Sensitivity (Garage)"
     },
     {
       "name": "mouse-sensitivity-drive",
-      "value": "Camera Sensitivity (Drive)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Camera Sensitivity (Drive)"
     },
     {
       "name": "zoom-sensitivity-zoom",
-      "value": "Camera Sensitivity (Scoped)",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Camera Sensitivity (Scoped)"
     },
     {
       "name": "controls-part-behaviors",
-      "value": "Part Behaviors",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Part Behaviors"
     },
     {
       "name": "tank-sprint-toggle",
-      "value": "Toggle Tank Track Gears",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Toggle Tank Track Gears"
     },
     {
       "name": "controls-keybindings",
-      "value": "Keybindings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Keybindings"
     },
     {
       "name": "keybinds-garage",
-      "value": "Garage & Building Keybinds",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Garage & Building Keybinds"
     },
     {
       "name": "keybinds-drive",
-      "value": "Testing & Battling Keybinds",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Testing & Battling Keybinds"
     },
     {
       "name": "keybinds-interface",
-      "value": "User Interface Keybinds",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "User Interface Keybinds"
     },
     {
       "name": "keybinds-misc",
-      "value": "Miscellaneous Keybinds",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Miscellaneous Keybinds"
     },
     {
       "name": "press-any-key",
-      "value": "PRESS ANY KEY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "PRESS ANY KEY"
     },
     {
       "name": "set-to-default",
-      "value": "set to defaults",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "set to defaults"
     },
     {
       "name": "setting-join-globalchat",
-      "value": "Join Global Chat",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Join Global Chat"
     },
     {
       "name": "game-testmode",
-      "value": "Testmode Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Testmode Settings"
     },
     {
       "name": "test-environment",
-      "value": "Test Environment",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Test Environment"
     },
     {
       "name": "game-aiamount",
-      "value": "AI Spawn Amount",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "AI Spawn Amount"
     },
     {
       "name": "game-aiaccuracy",
-      "value": "AI Shooting Accuracy",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "AI Shooting Accuracy"
     },
     {
       "name": "game-aidistance",
-      "value": "AI Engagement Distance",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "AI Engagement Distance"
     },
     {
       "name": "game-visuals",
-      "value": "Visual Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Visual Settings"
     },
     {
       "name": "settings-screenshake",
-      "value": "Screenshake Intensity",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Screenshake Intensity"
     },
     {
       "name": "ui-game-enhancedcamera",
-      "value": "Enhanced Follow-Bot Camera",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Enhanced Follow-Bot Camera"
     },
     {
       "name": "ui-game-motionsickness",
-      "value": "Reduce Motionsickness Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Reduce Motionsickness Mode"
     },
     {
       "name": "ui-game-reduceuimotion",
-      "value": "Reduce UI Motion",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Reduce UI Motion"
     },
     {
       "name": "ui-game-gaussboresight",
-      "value": "Gauss Boresight Scope",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Gauss Boresight Scope"
     },
     {
       "name": "ui-enable-dithering",
-      "value": "Enable Bot Dithering",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Enable Bot Dithering"
     },
     {
       "name": "ui-game-speedunits",
-      "value": "Speed Measurement",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Speed Measurement"
     },
     {
       "name": "game-buildmode",
-      "value": "Buildmode Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Buildmode Settings"
     },
     {
       "name": "garage-material",
-      "value": "Garage Environment\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Garage Environment\n"
     },
     {
       "name": "garage-background-login-error",
-      "value": "LOG IN FIRST",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "LOG IN FIRST"
     },
     {
       "name": "ui-do-autopurchase",
-      "value": "Auto-Purchase Parts In Build Mode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Auto-Purchase Parts In Build Mode"
     },
     {
       "name": "ui-build-widgets",
-      "value": "Show Build Part Widgets",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Show Build Part Widgets"
     },
     {
       "name": "ui-game-gizmo-collider",
-      "value": "Show Collision Box Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Show Collision Box Gizmos"
     },
     {
       "name": "ui-game-gizmo-lift",
-      "value": "Show Center of Lift Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Show Center of Lift Gizmos"
     },
     {
       "name": "ui-game-gizmo-thrust",
-      "value": "Show Center of Thrust Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Show Center of Thrust Gizmos"
     },
     {
       "name": "ui-game-gizmo-mass",
-      "value": "Show Center of Mass Gizmos",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Show Center of Mass Gizmos"
     },
     {
       "name": "settings-undolog",
-      "value": "Undo Log Length",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Undo Log Length"
     },
     {
       "name": "game-replay",
-      "value": "Replay Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Replay Settings"
     },
     {
       "name": "ui-save-matches",
-      "value": "Save Match Replays (avg 300KiB/player/min)",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Save Match Replays (avg 300KiB/player/min)"
     },
     {
       "name": "records-path",
-      "value": "Replay Save Location",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Replay Save Location"
     },
     {
       "name": "ui-game-client-physics",
-      "value": "Client-Driven Hybrid Physics",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Client-Driven Hybrid Physics"
     },
     {
       "name": "ui-game-async-load",
-      "value": "[DEBUG] Monothreaded Bot Spawning\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "[DEBUG] Monothreaded Bot Spawning\n"
     },
     {
       "name": "audio-general",
-      "value": "General Settings",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "General Settings"
     },
     {
       "name": "master-volume",
-      "value": "Master Volume\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Master Volume\n"
     },
     {
       "name": "sound-effects-volume",
-      "value": "Hit Effects Volume\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Hit Effects Volume\n"
     },
     {
       "name": "environmental-volume",
-      "value": "Environmental Volume",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Environmental Volume"
     },
     {
       "name": "music-volume",
-      "value": "Music Volume\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Music Volume\n"
     },
     {
       "name": "ui-audio-disableMissileAlarm",
-      "value": "Disable Missile Alarm",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Disable Missile Alarm"
     },
     {
       "name": "audio-music-selector",
-      "value": "Soundtrack Picker",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "Soundtrack Picker"
     },
     {
       "name": "game-area",
-      "value": "Current Area",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Current Area"
     },
     {
       "name": "inventory-button",
-      "value": "Inventory\n",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Inventory\n"
     },
     {
       "name": "shop-button",
-      "value": "Shop\n",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Shop\n"
     },
     {
       "name": "battle-button",
-      "value": "battle",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "battle"
     },
     {
       "name": "test-button",
-      "value": "TEST MODE",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "TEST MODE"
     },
     {
       "name": "tech-button",
-      "value": "Requisitions",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Requisitions"
     },
     {
       "name": "paint-button",
-      "value": "Paint",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Paint"
     },
     {
       "name": "currency-info-normal-title",
-      "value": "Company Credits",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Company Credits"
     },
     {
       "name": "currency-info-normal-desc",
-      "value": "Company credits are paid out for performance in battles.\n\nYou can spend your company credits on requisitions, parts, cosmetics, or prefabs.\n\nCredits are capped at 100k, to encourage employee expenditure.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Company credits are paid out for performance in battles.\n\nYou can spend your company credits on requisitions, parts, cosmetics, or prefabs.\n\nCredits are capped at 100k, to encourage employee expenditure."
     },
     {
       "name": "currency-info-premium-title",
-      "value": "Premium Chips",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [63, 129, 190]
+      "value": "Premium Chips"
     },
     {
       "name": "currency-info-premium-desc",
-      "value": "Premium chips are a special currency awarded through achievements, events, and external purchases.\n\n\nin-game purchases for premium chips are disabled until we have a product we feel is worth monetizing.\n\n\nYour support means the world to us, in any form.\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Premium chips are a special currency awarded through achievements, events, and external purchases.\n\n\nin-game purchases for premium chips are disabled until we have a product we feel is worth monetizing.\n\n\nYour support means the world to us, in any form.\n"
     },
     {
       "name": "credit-cap-warning-title",
-      "value": "credit cap hit",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "credit cap hit"
     },
     {
       "name": "credit-cap-warning-desc",
-      "value": "Osprey Modular Hardware regrets to inform you that you have hit the internal company credit cap alloted to Zulu-class employees. \n\nConsider spending your company credits on requisitions, parts, cosmetics, or prefabs.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Osprey Modular Hardware regrets to inform you that you have hit the internal company credit cap alloted to Zulu-class employees. \n\nConsider spending your company credits on requisitions, parts, cosmetics, or prefabs."
     },
     {
       "name": "max-amp-exceeded",
-      "value": "Power Capacity Exceeded!",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "Power Capacity Exceeded!"
     },
     {
       "name": "return-to-main-menu",
-      "value": "return",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "return"
     },
     {
       "name": "garage-customization",
-      "value": "environment",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "environment"
     },
     {
       "name": "logbook",
-      "value": "LOGBOOK",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LOGBOOK"
     },
     {
       "name": "friends",
-      "value": "friends",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "friends"
     },
     {
       "name": "prefabs-menu-button",
-      "value": "PREFABS",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "PREFABS"
     },
     {
       "name": "clipboard-copy",
-      "value": "COPY\n",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "COPY\n"
     },
     {
       "name": "clipboard-paste",
-      "value": "PASTE",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "PASTE"
     },
     {
       "name": "copy-bot",
-      "value": "COPY",
-      "bold": true,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 2,
-      "color": [255, 117, 0]
+      "value": "COPY"
     },
     {
       "name": "copy-bot-clipboard",
-      "value": "CLIPBOARD BAY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "CLIPBOARD BAY"
     },
     {
       "name": "robot-name",
-      "value": "BOT NAME",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "BOT NAME"
     },
     {
       "name": "configure-bot",
-      "value": "configure",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "configure"
     },
     {
       "name": "edit-bot",
-      "value": "EDIT ROBOT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "EDIT ROBOT"
     },
     {
       "name": "delete-bot",
-      "value": "delete",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "delete"
     },
     {
       "name": "configure-garage-title",
-      "value": "CUSTOMIZE GARAGE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "CUSTOMIZE GARAGE"
     },
     {
       "name": "configure-garage-screens",
-      "value": "employee enrichment panels",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "employee enrichment panels"
     },
     {
       "name": "configure-garage-map",
-      "value": "TESTING SIMULATION ENVIRONMENT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "TESTING SIMULATION ENVIRONMENT"
     },
     {
       "name": "configure-garage-bots",
-      "value": "TESTING SIMULATION SETTINGS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "TESTING SIMULATION SETTINGS"
     },
     {
       "name": "configure-robot-title",
-      "value": "CONFIGURE ROBOT:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "CONFIGURE ROBOT:"
     },
     {
       "name": "bot-remaps-global",
-      "value": "set global keybind profile",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "set global keybind profile"
     },
     {
       "name": "bot-control-remapping",
-      "value": "Control Overrides",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Control Overrides"
     },
     {
       "name": "bot-control-remapping-reset",
-      "value": "reset",
-      "size": 27,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "reset"
     },
     {
       "name": "bot-control-remapping-instructions",
-      "value": "BOT ACTION < < < < < USER INPUT",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "BOT ACTION < < < < < USER INPUT"
     },
     {
       "name": "chat-server-connection-lost",
-      "value": "Cannot connect to Chat Server.",
-      "size": 24,
-      "bold": false,
-      "italic": true,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "Cannot connect to Chat Server."
     },
     {
       "name": "reward-screen-title",
-      "value": "YOU'VE RECIEVED",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "YOU'VE RECIEVED"
     },
     {
       "name": "ui-dialogue-continue",
-      "value": "Continue",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Continue"
     },
     {
       "name": "hud-module-dead",
-      "value": "ERROR\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [254, 56, 56]
+      "value": "ERROR\n"
     },
     {
       "name": "dashboard-stat-hp",
-      "value": "integrity",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "integrity"
     },
     {
       "name": "dashboard-stat-",
-      "value": "encumbered",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "encumbered"
     },
     {
       "name": "dashboard-stat-barrier",
-      "value": "BARRIER",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [155, 0, 253]
+      "value": "BARRIER"
     },
     {
       "name": "dashboard-stat-invincible",
-      "value": "Invincible",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [62, 199, 62]
+      "value": "Invincible"
     },
     {
       "name": "dashboard-stat-thrust",
-      "value": "turbofuel",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [62, 199, 62]
+      "value": "turbofuel"
     },
     {
       "name": "dashboard-stat-chaff",
-      "value": "Chaff",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [62, 199, 62]
+      "value": "Chaff"
     },
     {
       "name": "dashboard-stat-damage-vulnerable",
-      "value": "fragile",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "fragile"
     },
     {
       "name": "dashboard-stat-healbane",
-      "value": "flux virus",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "flux virus"
     },
     {
       "name": "dashboard-stat-overdraw",
-      "value": "overdraw",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "overdraw"
     },
     {
       "name": "dashboard-stat-oob",
-      "value": "awol",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "awol"
     },
     {
       "name": "dashboard-meter-",
-      "value": "METER",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "METER"
     },
     {
       "name": "dashboard-meter-collective",
-      "value": "collective",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "collective"
     },
     {
       "name": "dashboard-meter-lta",
-      "value": "LTA",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LTA"
     },
     {
       "name": "flip-instruction-completed",
-      "value": "THANK YOU FOR\nFLYING WITH OSPREY",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [207, 117, 0]
+      "value": "THANK YOU FOR\nFLYING WITH OSPREY"
     },
     {
       "name": "return-to-battle-warning",
-      "value": "RETURN TO THE BATTLE",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "RETURN TO THE BATTLE"
     },
     {
       "name": "oob-terminated",
-      "value": "ROBOT TERMINATED",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 8,
-      "color": [255, 117, 0]
+      "value": "ROBOT TERMINATED"
     },
     {
       "name": "oob-standby",
-      "value": "PLEASE STAND BY",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 2,
-      "color": [180, 83, 0]
+      "value": "PLEASE STAND BY"
     },
     {
       "name": "oob-uplink-killed",
-      "value": "REMOTE ROBOTICS UPLINK SERVICES",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 117, 0]
+      "value": "REMOTE ROBOTICS UPLINK SERVICES"
     },
     {
       "name": "oob-console",
-      "value": "Robot control connection interrupted.\nERRx02: Connection Terminated.\n\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 117, 0]
+      "value": "Robot control connection interrupted.\nERRx02: Connection Terminated.\n\n"
     },
     {
       "name": "oob-uplink",
-      "value": "REMOTE ROBOTICS UPLINK SERVICES",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [40, 40, 40]
+      "value": "REMOTE ROBOTICS UPLINK SERVICES"
     },
     {
       "name": "respawn-console",
-      "value": "Robot control connection interrupted.\nERRx01: Out of Control Range.\n\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [40, 40, 40]
+      "value": "Robot control connection interrupted.\nERRx01: Out of Control Range.\n\n"
     },
     {
       "name": "oob-disconnected",
-      "value": "ROBOT DISCONNECTED",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 8,
-      "color": [180, 83, 0]
+      "value": "ROBOT DISCONNECTED"
     },
     {
       "name": "oob-username",
-      "value": "USER ID:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [40, 40, 40]
+      "value": "USER ID:"
     },
     {
       "name": "oob-lastlocation",
-      "value": "LAST KNOWN LOCATION:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [40, 40, 40]
+      "value": "LAST KNOWN LOCATION:"
     },
     {
       "name": "respawn-redeployment",
-      "value": "REDEPLOYMENT IN...",
-      "size": 32,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "REDEPLOYMENT IN..."
     },
     {
       "name": "bot-deck-active",
-      "value": "ACTIVE",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [40, 40, 40]
+      "value": "ACTIVE"
     },
     {
       "name": "bot-deck-queued",
-      "value": "QUEUED",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [40, 40, 40]
+      "value": "QUEUED"
     },
     {
       "name": "online-battles-not-paused",
-      "value": "Online Battles are not paused!",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 2,
-      "color": [254, 56, 56]
+      "value": "Online Battles are not paused!"
     },
     {
       "name": "return-to-game",
-      "value": "RETURN TO GAME",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "RETURN TO GAME"
     },
     {
       "name": "self-destruct",
-      "value": "SELF-DESTRUCT",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SELF-DESTRUCT"
     },
     {
       "name": "quit-to-garage",
-      "value": "QUIT TO GARAGE",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "QUIT TO GARAGE"
     },
     {
       "name": "language-settings-title",
-      "value": "LANGUAGE SETTINGS",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LANGUAGE SETTINGS"
     },
     {
       "name": "translation-download",
-      "value": "DOWNLOAD",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "DOWNLOAD"
     },
     {
       "name": "translation-installed",
-      "value": "INSTALLED",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "INSTALLED"
     },
     {
       "name": "translation-enabled",
-      "value": "Enabled\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Enabled\n"
     },
     {
       "name": "translation-disabled",
-      "value": "Disabled\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "Disabled\n"
     },
     {
       "name": "paint-menu",
-      "value": "PAINT MIXER",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "PAINT MIXER"
     },
     {
       "name": "PAINT-PALETTES",
-      "value": "PALETTES",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "PALETTES"
     },
     {
       "name": "paint-create-palette",
-      "value": "CREATE NEW PALETTE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "CREATE NEW PALETTE"
     },
     {
       "name": "paint-palette-equipped",
-      "value": "EQUIPPED",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 7,
-      "color": [255, 117, 0]
+      "value": "EQUIPPED"
     },
     {
       "name": "pant-open-paint-tool",
-      "value": "OPEN PAINT TOOL",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "OPEN PAINT TOOL"
     },
     {
       "name": "add-to-palette",
-      "value": "SAVE COLOR",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SAVE COLOR"
     },
     {
       "name": "copy-palette-color",
-      "value": "COPY COLOR",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "COPY COLOR"
     },
     {
       "name": "delete-palette-color",
-      "value": "DELETE COLOR",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "DELETE COLOR"
     },
     {
       "name": "check-dsar",
-      "value": "<- Check Req",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "<- Check Req"
     },
     {
       "name": "request-dsar",
-      "value": "Request data",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Request data"
     },
     {
       "name": "delete-account",
-      "value": "Delete Account",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Delete Account"
     },
     {
       "name": "license",
-      "value": "license",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "license"
     },
     {
       "name": "replay-warning",
-      "value": "replay files are version-dependant, and may not be compatible with future versions of procelio!",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "replay files are version-dependant, and may not be compatible with future versions of procelio!"
     },
     {
       "name": "view-replay",
-      "value": "View Replay",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "View Replay"
     },
     {
       "name": "logbook-title",
-      "value": "OSPREY EMPLOYEE LOGBOOK",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "OSPREY EMPLOYEE LOGBOOK"
     },
     {
       "name": "logbook-tutorial",
-      "value": "USER GUIDE",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "USER GUIDE"
     },
     {
       "name": "logbook-parts",
-      "value": "INVENTORY",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "INVENTORY"
     },
     {
       "name": "logbook-locations",
-      "value": "LOCATIONS",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LOCATIONS"
     },
     {
       "name": "logbook-history",
-      "value": "HISTORY",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "HISTORY"
     },
     {
       "name": "logbook-factions",
-      "value": "FACTIONS",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "FACTIONS"
     },
     {
       "name": "logbook-player-stats",
-      "value": "PLAYER LOG",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "PLAYER LOG"
     },
     {
       "name": "queue-step3-squad",
-      "value": "READY FOR DROP",
-      "size": 36,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "READY FOR DROP"
     },
     {
       "name": "queue-ready-up",
-      "value": "Ready Up",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 7,
-      "color": [255, 255, 255]
+      "value": "Ready Up"
     },
     {
       "name": "queue-squad-not-ready",
-      "value": "squad not ready",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "squad not ready"
     },
     {
       "name": "queue-squad-wait-for-host",
-      "value": "WAIT FOR HOST",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "WAIT FOR HOST"
     },
     {
       "name": "queue-queue-for-match",
-      "value": "enter queue",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "enter queue"
     },
     {
       "name": "queue-step2-botselect",
-      "value": "SELECT ROBOTS",
-      "size": 36,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "SELECT ROBOTS"
     },
     {
       "name": "queue-robotselector-tab-playerbots",
-      "value": "YOUR BOTS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "YOUR BOTS"
     },
     {
       "name": "queue-robotselector-tab-trialbots",
-      "value": "TRIAL BOTS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "TRIAL BOTS"
     },
     {
       "name": "queue-robotselector-tab-trialbotshint",
-      "value": "NEED MORE BOTS? TRY SOME!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [61, 130, 220]
+      "value": "NEED MORE BOTS? TRY SOME!"
     },
     {
       "name": "queue-robotselector-hide-invalid",
-      "value": "Hide Invalid Bots",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 7,
-      "color": [255, 255, 255]
+      "value": "Hide Invalid Bots"
     },
     {
       "name": "queue-robotselector-remember-deck",
-      "value": "Remember Deck",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 7,
-      "color": [255, 255, 255]
+      "value": "Remember Deck"
     },
     {
       "name": "queue-robotselector-dropdeck",
-      "value": "DROP DECK",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "DROP DECK"
     },
     {
       "name": "queue-botpicker-warning-1",
-      "value": "In Queue",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [40, 40, 40]
+      "value": "In Queue"
     },
     {
       "name": "queue-botpicker-warning-2",
-      "value": "Exit queue to edit drop deck.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 8,
-      "color": [128, 128, 128]
+      "value": "Exit queue to edit drop deck."
     },
     {
       "name": "gamemode-capture",
-      "value": "CAPTURE POINTS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "CAPTURE POINTS"
     },
     {
       "name": "gamedesc-capture",
-      "value": "Fight over multiple control points for victory.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "Fight over multiple control points for victory."
     },
     {
       "name": "gamemode-asset-extract",
-      "value": "ASSET EXTRACTION",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [128, 128, 128]
+      "value": "ASSET EXTRACTION"
     },
     {
       "name": "gamedesc-dm",
-      "value": "8v8 showdown. Last team standing wins.",
-      "size": 20,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 4,
-      "color": [255, 255, 255]
+      "value": "8v8 showdown. Last team standing wins."
     },
     {
       "name": "gamemode-TC",
-      "value": "DEATHMATCH",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "DEATHMATCH"
     },
     {
       "name": "queue-gamemode-warning-1",
-      "value": "Waiting for\nSquad Leader",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [40, 40, 40]
+      "value": "Waiting for\nSquad Leader"
     },
     {
       "name": "queue-gamemode-warning-2",
-      "value": "Only the squad leader can select gamemodes.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 8,
-      "color": [128, 128, 128]
+      "value": "Only the squad leader can select gamemodes."
     },
     {
       "name": "queue-gamemode-desc",
-      "value": "DESCRIPTION",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "DESCRIPTION"
     },
     {
       "name": "queue-gamemode-ruleset",
-      "value": "RULESET",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 127, 0]
+      "value": "RULESET"
     },
     {
       "name": "queue-gamemode-deselect",
-      "value": "deselect gamemode",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "deselect gamemode"
     },
     {
       "name": "floating-queue-title",
-      "value": "iN QUEUE...",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "iN QUEUE..."
     },
     {
       "name": "floating-queue=gamemode",
-      "value": "GAMEMODE:",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "GAMEMODE:"
     },
     {
       "name": "floating-queue-end-search",
-      "value": "cancel search",
-      "size": 32,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "cancel search"
     },
     {
       "name": "menu-button",
-      "value": "MENU",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "MENU"
     },
     {
       "name": "build-open-gizmos",
-      "value": "Open Gizmos Menu",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Open Gizmos Menu"
     },
     {
       "name": "gizmo-colliders",
-      "value": "Show Colliders",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Show Colliders"
     },
     {
       "name": "gizmo-center-of-lift",
-      "value": "Show Center of Lift",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Show Center of Lift"
     },
     {
       "name": "gizmo-center-of-thrust",
-      "value": "Show Center of Thrust",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Show Center of Thrust"
     },
     {
       "name": "gizmo-center-of-mass",
-      "value": "Show Center of Mass",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Show Center of Mass"
     },
     {
       "name": "toggle-mirror-type",
-      "value": "Toggle Mirror Type",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Toggle Mirror Type"
     },
     {
       "name": "toggle-mirror-mode",
-      "value": "Toggle Mirror Mode",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Toggle Mirror Mode"
     },
     {
       "name": "advanced-mode",
-      "value": "Advanced Mode",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Advanced Mode"
     },
     {
       "name": "inventory",
-      "value": "INVENTORY",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "INVENTORY"
     },
     {
       "name": "shop",
-      "value": "COMPONENT SHOP",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "COMPONENT SHOP"
     },
     {
       "name": "shop-help-title",
-      "value": "INFORMATION",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "INFORMATION"
     },
     {
       "name": "shop-help-desc",
-      "value": "LEFT CLICK to add a part to your purchase order.\n\nRIGHT CLICK to sell a part from your inventory.\n\nSHIFT + CLICK to add / sell 5x at a time.\n\nCTRL + CLICK to add / sell 10x at a time.\n\nHit CONFIRM to process the order.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "LEFT CLICK to add a part to your purchase order.\n\nRIGHT CLICK to sell a part from your inventory.\n\nSHIFT + CLICK to add / sell 5x at a time.\n\nCTRL + CLICK to add / sell 10x at a time.\n\nHit CONFIRM to process the order."
     },
     {
       "name": "buy",
-      "value": "CONFIRM",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "CONFIRM"
     },
     {
       "name": "clear",
-      "value": "Clear\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Clear\n"
     },
     {
       "name": "autobuy-help-desc",
-      "value": "When enabled, Osprey will automatically purchase parts as you place them in build mode. \n\nThis deducts the associated credits from your account and adds the part to your inventory in real time.\n\nNOTICE: Employee debts generated by auto-purchasing parts are non-refundable. Proceed with caution.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "When enabled, Osprey will automatically purchase parts as you place them in build mode. \n\nThis deducts the associated credits from your account and adds the part to your inventory in real time.\n\nNOTICE: Employee debts generated by auto-purchasing parts are non-refundable. Proceed with caution."
     },
     {
       "name": "techtree-wip",
-      "value": "UNDER CONSTRUCTION",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "UNDER CONSTRUCTION"
     },
     {
       "name": "techtree-wip-desc",
-      "value": "The Osprey modular hardware research and development department is being researched...\nand developed. come back later!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "The Osprey modular hardware research and development department is being researched...\nand developed. come back later!"
     },
     {
       "name": "techtree-menu",
-      "value": "REQUISITIONS TREE",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "REQUISITIONS TREE"
     },
     {
       "name": "need-help-button",
-      "value": "?",
-      "size": 50,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "?"
     },
     {
       "name": "need-help",
-      "value": "need help?",
-      "size": 27,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "need help?"
     },
     {
       "name": "tech-categories",
-      "value": "CATEGORIES\n",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 116, 0]
+      "value": "CATEGORIES\n"
     },
     {
       "name": "techtree-currentcategory",
-      "value": "VIEWING:",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "VIEWING:"
     },
     {
       "name": "techtree-background-text-2 ",
-      "value": "FLY WITH OSPREY",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 2,
-      "color": [0, 33, 76]
+      "value": "FLY WITH OSPREY"
     },
     {
       "name": "techpreview-instructions",
-      "value": "SELECT A \nNODE TO \nPREVIEW",
-      "size": 40,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [128, 128, 128]
+      "value": "SELECT A \nNODE TO \nPREVIEW"
     },
     {
       "name": "techinfo-cat-itemunlocks",
-      "value": "ITEM UNLOCKS",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "ITEM UNLOCKS"
     },
     {
       "name": "techinfo-cat-resourceawards",
-      "value": "RESOURCE AWARDS",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "RESOURCE AWARDS"
     },
     {
       "name": "award-new-garage-bay",
-      "value": "GARAGE BAY",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "GARAGE BAY"
     },
     {
       "name": "award-credits",
-      "value": "CREDIT BONUS",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "CREDIT BONUS"
     },
     {
       "name": "award-premium-currency",
-      "value": "PREMIUM CHIPS",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "PREMIUM CHIPS"
     },
     {
       "name": "techinfo-cat-prefabunlocks",
-      "value": "PREFAB LICENSES",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "PREFAB LICENSES"
     },
     {
       "name": "techinfo-cat-garageunlocks",
-      "value": "Garage Decor",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Garage Decor"
     },
     {
       "name": "techinfo-cat-testunlocks",
-      "value": "Test Tracks",
-      "size": 28,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Test Tracks"
     },
     {
       "name": "techtree-error-cost",
-      "value": "missing prerequisites",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "missing prerequisites"
     },
     {
       "name": "techtree-error-unlocked",
-      "value": "already unlocked!",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [62, 199, 62]
+      "value": "already unlocked!"
     },
     {
       "name": "unlock-tech-title",
-      "value": "requisition approved",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [255, 255, 255]
+      "value": "requisition approved"
     },
     {
       "name": "unlock-tech-cancel",
-      "value": "nevermind",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "nevermind"
     },
     {
       "name": "unlock-tech-confirm",
-      "value": "get back to work",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "get back to work"
     },
     {
       "name": "tech-help-title",
-      "value": "Requisitions Helpdesk",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 5,
-      "color": [255, 255, 255]
+      "value": "Requisitions Helpdesk"
     },
     {
       "name": "tech-help-desc",
-      "value": "Welcome to the Procelio Program Requisition Catalog. Here, you can spend your hard-earned company credits to unlock licenses to use new components on your bots. \n\nEach category has its own tree composed of nodes, and each node has prerequisites to fulfil. Click on a node to learn more about its contents and prerequisites. You can unlock nodes with credits once all of its prerequisites are met. Unlocking nodes unlocks their relevant equipment, items, or bonuses for your account, as well as provide access to nodes deeper in each tree.\n\nWhen a piece of equipment is unlocked, it becomes available for use in the garage. Most basic parts are available with no limits, while more advanced parts such as modules and cosmetics may require additional copies to be purchased in the shop.\n\nResource Awards are one-time bonuses of items applied to your account. All sales are final.\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Welcome to the Procelio Program Requisition Catalog. Here, you can spend your hard-earned company credits to unlock licenses to use new components on your bots. \n\nEach category has its own tree composed of nodes, and each node has prerequisites to fulfil. Click on a node to learn more about its contents and prerequisites. You can unlock nodes with credits once all of its prerequisites are met. Unlocking nodes unlocks their relevant equipment, items, or bonuses for your account, as well as provide access to nodes deeper in each tree.\n\nWhen a piece of equipment is unlocked, it becomes available for use in the garage. Most basic parts are available with no limits, while more advanced parts such as modules and cosmetics may require additional copies to be purchased in the shop.\n\nResource Awards are one-time bonuses of items applied to your account. All sales are final.\n"
     },
     {
       "name": "tech-help-return",
-      "value": "understood",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "understood"
     },
     {
       "name": "exit-test-mode",
-      "value": "| L",
-      "size": 38,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "| L"
     },
     {
       "name": "toggle-damage-tester",
-      "value": "Toggle Damage Tester",
-      "size": 24,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Toggle Damage Tester"
     },
     {
       "name": "damagetest-weapon-select",
-      "value": "Selected Weapon Class:",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Selected Weapon Class:"
     },
     {
       "name": "dmg-test-scale",
-      "value": "x3",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "x3"
     },
     {
       "name": "damagetest-damage-scale",
-      "value": "damage scale",
-      "size": 22,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "damage scale"
     },
     {
       "name": "prefab-source",
-      "value": "Prefab Source",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "Prefab Source"
     },
     {
       "name": "remove-online-prefab",
-      "value": "remove",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "remove"
     },
     {
       "name": "prefab-source-personal",
-      "value": "LOCAL",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LOCAL"
     },
     {
       "name": "prefab-source-friends",
-      "value": "friends",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "friends"
     },
     {
       "name": "prefab-source-unlocked",
-      "value": "UNLOCKED",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "UNLOCKED"
     },
     {
       "name": "prefab-source-all",
-      "value": "ALL PREFABS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "ALL PREFABS"
     },
     {
       "name": "prefabs-search-prefabs",
-      "value": "SEARCH PREFABS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "SEARCH PREFABS"
     },
     {
       "name": "prefab-local-export",
-      "value": "local export",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 8,
-      "color": [255, 255, 255]
+      "value": "local export"
     },
     {
       "name": "prefab-cloud-upload",
-      "value": "cloud upload",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 8,
-      "color": [255, 255, 255]
+      "value": "cloud upload"
     },
     {
       "name": "shared-prefabs-header",
-      "value": "SHARED PREFABS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "SHARED PREFABS"
     },
     {
       "name": "shared-prefabs-desc",
-      "value": "Upload bots to share with your friends list automatically. up to three bots can be shared at once. friends can view and download these bots.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Upload bots to share with your friends list automatically. up to three bots can be shared at once. friends can view and download these bots."
     },
     {
       "name": "upload-online-prefab",
-      "value": "upload",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "upload"
     },
     {
       "name": "prefabs-search-BOTS",
-      "value": "SEARCH BOTS",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 117, 0]
+      "value": "SEARCH BOTS"
     },
     {
       "name": "import-prefab",
-      "value": "import prefab",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "import prefab"
     },
     {
       "name": "prefab-import-only-available-parts",
-      "value": "Only Import Owned Parts",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Only Import Owned Parts"
     },
     {
       "name": "prefab-warning-overamp",
-      "value": "file '???' imported",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [62, 199, 62]
+      "value": "file '???' imported"
     },
     {
       "name": "prefab-warning-invalid",
-      "value": "PREFAB IS INVALID FOR COMBAT",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "PREFAB IS INVALID FOR COMBAT"
     },
     {
       "name": "prefab-warning-cosmetics",
-      "value": "Prefab contains cosmetics",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "Prefab contains cosmetics"
     },
     {
       "name": "prefab-warning-premium",
-      "value": "Prefab contains premium cosmetics",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 162, 52]
+      "value": "Prefab contains premium cosmetics"
     },
     {
       "name": "prefab-error-parts-unpurchased",
-      "value": "Prefab CONTAINS PARTS YOU DO NOT OWN",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "Prefab CONTAINS PARTS YOU DO NOT OWN"
     },
     {
       "name": "prefab-error-parts-unavailable",
-      "value": "Prefab contains unavailable parts",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "Prefab contains unavailable parts"
     },
     {
       "name": "prefab-error-parts-locked",
-      "value": "Prefab contains parts you have not unlocked",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "Prefab contains parts you have not unlocked"
     },
     {
       "name": "prefab-error-cost",
-      "value": "Cannot afford import fees",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "Cannot afford import fees"
     },
     {
       "name": "prefab-error-failsafe",
-      "value": "PREFAB IS CORRUPTED OR INVALID- TELL DEVS",
-      "size": 30,
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [254, 56, 56]
+      "value": "PREFAB IS CORRUPTED OR INVALID- TELL DEVS"
     },
     {
       "name": "confirm-prefab-import",
-      "value": "confirm import",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "confirm import"
     },
     {
       "name": "confirm-prefab-import-desc",
-      "value": "Are you sure you want to import prefab [prefabnamehere] into bay [baynumberhere]?\n\nThis action cannot be reversed.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Are you sure you want to import prefab [prefabnamehere] into bay [baynumberhere]?\n\nThis action cannot be reversed."
     },
     {
       "name": "dialogue-succes",
-      "value": "Success!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "Success!"
     },
     {
       "name": "prefab-export-confirmation",
-      "value": "Robot saved to local backup folder.",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 255, 255]
+      "value": "Robot saved to local backup folder."
     },
     {
       "name": "botfileimport-button",
-      "value": "GOT OLD .bot FILES?\nIMPORT THEM HERE!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "GOT OLD .bot FILES?\nIMPORT THEM HERE!"
     },
     {
       "name": "botfile-import-header",
-      "value": "LEGACY .BOT FILE IMPORTER",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "LEGACY .BOT FILE IMPORTER"
     },
     {
       "name": "botfile-import-subheader",
-      "value": "AVAILABLE FOR A LIMITED TIME ONLY!",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 162, 52]
+      "value": "AVAILABLE FOR A LIMITED TIME ONLY!"
     },
     {
       "name": "botfile-import-desc",
-      "value": "Thank you for playing Procelio during our Alpha phase! If you have any old .bot files exported from the proceliotool bot manager program, you can freely import them as local prefabs here. Local prefabs are our official in-game replacement for the old bot manager program.\n\nTo import your old files, copy the full file path leading either to the directory housing your bot files, or to a bot file directly, and paste it into the field below. If the bot files are located and valid, they will be turned into local prefabs for future import. \n\nExample 1: C:\\Users\\[YOU]\\Documents\\Your_Procelio_Bots\nExample 2: C:\\Users\\[YOU]\\Documents\\Your_Procelio_Bots\\myrobot.bot\n\nDo note that you will need to unlock the parts on your robot before you can import it. This service will only be available for a limited time, and will be discontinued some time after our Steam launch, alongside the deprecation of the bot manager program.\n",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 10,
-      "color": [255, 255, 255]
+      "value": "Thank you for playing Procelio during our Alpha phase! If you have any old .bot files exported from the proceliotool bot manager program, you can freely import them as local prefabs here. Local prefabs are our official in-game replacement for the old bot manager program.\n\nTo import your old files, copy the full file path leading either to the directory housing your bot files, or to a bot file directly, and paste it into the field below. If the bot files are located and valid, they will be turned into local prefabs for future import. \n\nExample 1: C:\\Users\\[YOU]\\Documents\\Your_Procelio_Bots\nExample 2: C:\\Users\\[YOU]\\Documents\\Your_Procelio_Bots\\myrobot.bot\n\nDo note that you will need to unlock the parts on your robot before you can import it. This service will only be available for a limited time, and will be discontinued some time after our Steam launch, alongside the deprecation of the bot manager program.\n"
     },
     {
       "name": "botfile-import",
-      "value": "import",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 0,
-      "color": [255, 255, 255]
+      "value": "import"
     },
     {
       "name": "botfile-import-filepath",
-      "value": "import file path",
-      "bold": false,
-      "italic": false,
-      "underline": false,
-      "strikethrough": false,
-      "alignment": 1,
-      "color": [255, 162, 52]
+      "value": "import file path"
     },
     {
       "name": "infolog_ffffff_test_run_please_ignore-title",

--- a/files/ENGLISH/style.json
+++ b/files/ENGLISH/style.json
@@ -1,0 +1,6 @@
+{
+  "meta": {
+    "description": "Optional style overrides applied on top of files/shared_style.json"
+  },
+  "by_key": {}
+}

--- a/files/PIRATESPEAK/language.json
+++ b/files/PIRATESPEAK/language.json
@@ -582,12 +582,7 @@
     },
     {
       "name": "confirm-password",
-      "value": "CONFIRM PASSCODE:",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "CONFIRM PASSCODE:"
     },
     {
       "name": "conn-files-failed-description",
@@ -635,12 +630,7 @@
     },
     {
       "name": "dmg-test-scale",
-      "value": "x3",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "x3"
     },
     {
       "name": "early-access-title",
@@ -660,12 +650,7 @@
     },
     {
       "name": "email-to-reset-password",
-      "value": "EMAIL:",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "EMAIL:"
     },
     {
       "name": "enter-game",
@@ -677,18 +662,15 @@
     },
     {
       "name": "enter-passord",
-      "value": "ENTER PASSCODE...",
-      "italic": true
+      "value": "ENTER PASSCODE..."
     },
     {
       "name": "enter-to-type",
-      "value": "Press ENTER if ye dare...",
-      "italic": true
+      "value": "Press ENTER if ye dare..."
     },
     {
       "name": "enter-username",
-      "value": "ENTER NICKNAME",
-      "italic": true
+      "value": "ENTER NICKNAME"
     },
     {
       "name": "environmental-volume",
@@ -1336,12 +1318,7 @@
     },
     {
       "name": "password",
-      "value": "PASSCODE:",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "PASSCODE:"
     },
     {
       "name": "play-button",
@@ -1353,12 +1330,7 @@
     },
     {
       "name": "power-usage",
-      "value": "WIT LIMIT",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "WIT LIMIT"
     },
     {
       "name": "quit-to-garage",
@@ -1366,8 +1338,7 @@
     },
     {
       "name": "re-enter-password",
-      "value": "captain@procelio.com",
-      "italic": true
+      "value": "captain@procelio.com"
     },
     {
       "name": "records-path",
@@ -1491,12 +1462,7 @@
     },
     {
       "name": "techtree-wip",
-      "value": "UNDER CONSTRUCTION",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "UNDER CONSTRUCTION"
     },
     {
       "name": "techtree-wip-desc",
@@ -1540,12 +1506,7 @@
     },
     {
       "name": "translation-disabled",
-      "value": "NOT READY\n",
-      "color": [
-        128,
-        128,
-        128
-      ]
+      "value": "NOT READY\n"
     },
     {
       "name": "translation-download",
@@ -1553,12 +1514,7 @@
     },
     {
       "name": "translation-enabled",
-      "value": "READY\n",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "READY\n"
     },
     {
       "name": "translation-installed",
@@ -1582,12 +1538,7 @@
     },
     {
       "name": "username",
-      "value": "NICKNAME:",
-      "color": [
-        255,
-        117,
-        0
-      ]
+      "value": "NICKNAME:"
     },
     {
       "name": "video-settings-title",

--- a/files/PIRATESPEAK/style.json
+++ b/files/PIRATESPEAK/style.json
@@ -1,0 +1,82 @@
+{
+  "meta": {
+    "description": "Optional style overrides applied on top of files/shared_style.json"
+  },
+  "by_key": {
+    "confirm-password": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "dmg-test-scale": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "email-to-reset-password": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "enter-passord": {
+      "italic": true
+    },
+    "enter-to-type": {
+      "italic": true
+    },
+    "enter-username": {
+      "italic": true
+    },
+    "password": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "power-usage": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "re-enter-password": {
+      "italic": true
+    },
+    "techtree-wip": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "translation-disabled": {
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "translation-enabled": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "username": {
+      "color": [
+        255,
+        117,
+        0
+      ]
+    }
+  }
+}

--- a/files/shared_style.json
+++ b/files/shared_style.json
@@ -1,0 +1,13164 @@
+{
+  "meta": {
+    "description": "Shared style baseline"
+  },
+  "by_key": {
+    "dialogue-okay": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dialogue-success": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "terms-changed-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "terms-changed-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "login-failed-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "login-badcreds-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "login-sessionexpired-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "login-networkfail-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "login-servererror-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "login-failedtosteam-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-server-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-assets-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-player-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-robots-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-error-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-error-stats-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-error-accountstate-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-error-cullbots-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "loading-error-techtree-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "conn-files-failed-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "conn-files-failed-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-pwmismatch-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-noagreement-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-pwtoolong-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-pwtooshort-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-usertoolong-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-userbad-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-usernaughty-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-emailused-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-userused-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-bademail-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-network-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-server-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-success-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-create-err-steamfail-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-link-err-steamlink-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-link-err-standalonelink-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-link-err-steamconflict-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "acct-link-err-authfail-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "confirm-graphics-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "confirm-graphics-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdriveforward": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdrivebackward": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdriveleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdriveright": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdriveup": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdrivedown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotpitchup": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotpitchdown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdriveturnleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotdriveturnright": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotrollleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotrollright": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotyawleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robotyawright": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageplaceblock": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageremoveblock": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-mousex": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-mousey": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-uimusicmute": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-uimusicskip": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-showcursor": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagepickblock": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagewipecosmetics": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagecammoveforward": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagecammovebackward": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagecamstrafeleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagecamstraferight": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagecammoveup": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagecammovedown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageshiftrobotforward": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageshiftrobotbackward": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageshiftrobotleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageshiftrobotright": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageshiftrobotup": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageshiftrobotdown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagerotaterobotleft": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagerotaterobotright": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagerotateghostx": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagerotateghosty": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagerotateghostz": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageundoredo": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageredomodifier": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagechangesymmetry": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagetogglemirroractive": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagechangeeditingmode": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageenableadvanced": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagewipebay": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivecheckscores": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-driveflipbot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-driveshoot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivescope": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivezoom": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivecamzoomin": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivecamzoomout": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivereload": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivedrift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivecycleweapon": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-battleentityspot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-battleentityping": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutmenu2battle": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutmenu2garage": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutmenu2stats": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutmenu2settings": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutmenu2exit": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutsettings2settings1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutsettings2settings2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutsettings2settings3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutsettings2settings4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuild2inventory": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuild2shop": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuild2tech": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuild2test": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuild2battle": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuild2paint": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar5": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar6": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar7": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar8": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar9": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcutbuildhotbar0": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-shortcuttest2damage": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-uiminimaptoggle": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-uiminimapscale": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-uitogglefps": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-battlemapping": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivemodule1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivemodule2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivemodule3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivemodule4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivemodule5": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-drivemodule6": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-functiontoggleui": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-functionselfdestruct": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robottogglecosmetics": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-robothorn": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-gizmostogglecollisionboxes": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-gizmostogglecenteroflift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-gizmostogglecenterofthrust": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-gizmostogglecenterofmass": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-gizmosdisableall": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageraisebuildplate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagelowerbuildplate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garageresetbuildplate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "key-garagerotatebuildplate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "paint-palette-presets": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "paint-palette-standard": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mapname-alpha-prospect": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mapname-deimos-nexus": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mapname-feldspar-valley": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mapname-icarus-north": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "maplocation-home-high-mars-orbit": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "maplocation-alpha-prospect": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "maplocation-deimos-nexus": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "maplocation-feldspar-valley": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "maplocation-icarus-north": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "enter-to-type": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "report-cause-chatbehavior": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "report-cause-obscenebot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "report-cause-hacking": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-playercount-connected": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-unknown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-weaponry": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-movement": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-structure": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-modules": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-extras": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-category-progression": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-background-text": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "techtree-background-text-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ai-objective-hunt": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ai-objective-wander": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ai-objective-objectivewait": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ai-objective-objectivefind": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-tooltip-availability": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-health": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-shield": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-shieldRate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-shieldDelay": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-mass": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-cpu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-price": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-prem-price": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-thrust": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-rots": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-lift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-minlift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-liftctrl": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-damage": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "stat-secondaryammovalue": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-knockback": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-cooldown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-activationcooldown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-range": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-dashspeed": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-dashduration": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-buffduration": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-chaffcloudduration": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-capacity": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-rechargerate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-rechargedelay": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-passivedrain": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-activedrain": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-activationcost": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-thrustmultiplier": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-restockrate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-dampen": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-nominalcount": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-wingcontrol": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-winglift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-wingstability": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-wingdrag": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-vectorthrust": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-falloffstart": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-falloffend": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-aoeradius": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-aoefalloff": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-fluxrestockrate": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-secondarymagazinecap": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-secondaryreserveammo": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-secondaryreloaddelay": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "auxstat-secondarycharges": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-0": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-5": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-6": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-7": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-8": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-9": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-10": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-11": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-12": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-13": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-14": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-15": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-16": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-17": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "garagebackground-18": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_gun_camo-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_gun_camo-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskinplaceholder2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskinplaceholder2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskinplaceholder3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskinplaceholder3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-gun_skin_nova_bomber-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-gun_skin_nova_bomber-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskinplaceholder5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskinplaceholder5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskingoldgauss-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskingoldgauss-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskincarbongauss-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-weaponskincarbongauss-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_gun_primary_supporter-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_gun_primary_supporter-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_gun_secondary_supporter-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_gun_secondary_supporter-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_mov_wing_fed-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_mov_wing_fed-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_mov_wing_camo-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_mov_wing_camo-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_mov_wing_supporter-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_mov_wing_supporter-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_module_supporter-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-skin_module_supporter-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowred-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowred-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowblue-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowblue-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowyellow-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowyellow-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowgreen-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowgreen-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowpurple-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowpurple-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partgloworange-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partgloworange-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowwhite-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowwhite-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowblack-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowblack-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowmilitary-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowmilitary-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowbee-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowbee-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowice-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowice-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowdarkred-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowdarkred-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowpurpulse-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowpurpulse-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowthunder-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowthunder-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowearth-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowearth-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowrainbow-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-partglowrainbow-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterncube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterncube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterntri1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterntri1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterntri2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterntri2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterntri3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterntri3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterncarbon-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterncarbon-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterncamo-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatterncamo-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternprem1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternprem1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternprem2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternprem2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternprem3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternprem3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternclassic-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternclassic-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternsupporter-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternsupporter-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustpurple-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustpurple-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustblue-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustblue-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustmusic-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustmusic-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustplasma-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustplasma-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustglow-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustglow-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustpan-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustpan-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustgreen-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustgreen-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustrings-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustrings-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustclassic-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustclassic-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhausthexglow-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhausthexglow-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustwireframe-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustwireframe-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustspiral-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustspiral-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustcordium-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustcordium-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustph4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustph4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustph5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustph5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustph6-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-thrusterexhaustph6-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-horn_alt_4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternhlwn122-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternhlwn122-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternhlwn222-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternhlwn222-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternxmas122-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternxmas122-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternxmas222-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "cosmetic-electroplatepatternxmas222-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-blocks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-heavyblocks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-glassblocks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-aeroframe": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-core": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-viz": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-electroplates": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-module": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-movement": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-groundmovement": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-wings": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-thrusters": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-LTA": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-wep-pri": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-wep-sec": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-wep": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-mov": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-thruster": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-pattern": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-glow": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-stickers": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-cosm-supporter": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "inv-cat-info": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-laser": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-gauss": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-plasma": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-nano": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-rivet": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-mwave": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-salvo": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-trace": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-slablauncher": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-missile": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-mine": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-tesla": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-smoke": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-minigun": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-bomb": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-assaultgauss": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-tripwire": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-fluxlauncher": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "weapon-category-rocketpod": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_1x2core-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_1x2core-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whitecube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whitecube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whiteinner-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whiteinner-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whiteprism-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whiteprism-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whitetetra-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whitetetra-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whitepyramid-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_whitepyramid-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavycube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavycube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavyinner-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavyinner-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavyprism-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavyprism-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavytetra-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavytetra-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavypyramid-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_heavypyramid-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glasscube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glasscube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glassinner-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glassinner-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glassprism-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glassprism-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glasstetra-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glasstetra-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glasspyramid-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_glasspyramid-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothcube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothcube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothinner-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothinner-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothprism-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothprism-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothtetra-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothtetra-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothpyramid-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_smoothpyramid-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carboncube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carboncube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carboninner-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carboninner-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carbonprism-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carbonprism-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carbontetra-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carbontetra-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carbonpyramid-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_carbonpyramid-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight3_flat-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight3_flat-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight5_flat-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight5_flat-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight6-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_straight6-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_angled3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_angled3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_angled5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_angled5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_tjunction3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_airframe_tjunction3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_thruster_t1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_thruster_t1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_topmount_thruster-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_topmount_thruster-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_thruster_t5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_thruster_t5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_thruster_t9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_thruster_t9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_turbofan_thruster-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_turbofan_thruster-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_small-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_small-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_small_topmount-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_small_topmount-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_medium-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_medium-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_medium_flat-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_medium_flat-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_large-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_thruster_large-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wheel_t9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wheel_t9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_nonsteering_wheel-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_nonsteering_wheel-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_hoverblade_t9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_hoverblade_t9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_ski-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_ski-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_repulsor_pad-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_repulsor_pad-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_tank_track_left-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_tank_track_left-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_tank_track_right-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_tank_track_right-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_tank_track_central-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_tank_track_central-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_leg_small-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_leg_small-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_leg_medium-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_leg_medium-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_leg_large-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_leg_large-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_wing_flat-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_wing_flat-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_wing_swept-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_wing_swept-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_wing_delta-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_wing_delta-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_rud_flat-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_rud_flat-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_rud_swept-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_rud_swept-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_rud_delta-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_rud_delta-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_swept_l-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_swept_l-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_swept_r-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_swept_r-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_flat_l-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_flat_l-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_flat_r-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_wing_flat_r-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_rudder-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_rudder-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_large_rudder-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_large_rudder-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_rudder_i-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_rudder_i-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_large_rudder_i-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_large_rudder_i-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_copter_large-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_copter_large-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_copter_small-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_copter_small-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_copter_tail-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mov_copter_tail-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_gyroscope-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_gyroscope-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_radar-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_radar-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_radar_jammer-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_radar_jammer-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_lasergun_t9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_lasergun_t9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_railgun-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_railgun-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_plasmacannon-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_plasmacannon-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_nanoassembler-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_nanoassembler-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_rivetrifle-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_rivetrifle-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_macrowave-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_macrowave-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_missile_salvo-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_missile_salvo-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_trace_missile-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_trace_missile-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_slab_launcher-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_slab_launcher-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_assault_railgun-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_assault_railgun-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_flux_launcher-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_flux_launcher-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_energyblade-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_energyblade-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_minelayer-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_minelayer-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_missilelauncher-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_missilelauncher-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_shieldprojector-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_shieldprojector-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_smokescreen-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_smokescreen-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_minigun-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_minigun-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_bombbay-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_bombbay-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_tripwire-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_tripwire-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_rocketpod-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_sec_rocketpod-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_a_l-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_a_l-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_a_r-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_a_r-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_b_l-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_b_l-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_b_r-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_b_r-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_c-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-electroplate_c-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_3_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_3_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_5_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_5_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_6-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_6-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_6_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_6_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_7-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_7-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_8-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_8-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_9_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_9_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_10-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-chassis_shield_10-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_112-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_112-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_123-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_123-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_224-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_224-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_335-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_335-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_348-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-helium_348-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_devonly_antigrav-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_devonly_antigrav-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_dash-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_dash-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_flare-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_flare-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_fuel-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_fuel-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_shockwave-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_shockwave-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_overshield-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_overshield-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_spoofer-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_spoofer-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_forge-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-mod_forge-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-module_8-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-module_8-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-module_9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-module_9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-module_10-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-module_10-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-ammo_box_small-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-ammo_box_small-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-ammo_box_large-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-ammo_box_large-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-energy_capacitor_small-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-energy_capacitor_small-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-energy_capacitor_large-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-energy_capacitor_large-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_isopod_cosmetic-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_isopod_cosmetic-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_isopod_xmas-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_isopod_xmas-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_isopod_nwyrs23-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_isopod_nwyrs23-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_headlight_standard-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_headlight_standard-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_headlight_popup-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_headlight_popup-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_headlight_aimable-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_headlight_aimable-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_vapor_cosmetic-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_vapor_cosmetic-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sirenlight-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sirenlight-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sirenlight_orange-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sirenlight_orange-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-horn-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-horn-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_arm-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_arm-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_exhaust-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_exhaust-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_kitt-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_kitt-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smallantenna-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smallantenna-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_antenna_side-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_antenna_side-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largeantenna-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largeantenna-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smallspike-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smallspike-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largespike-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largespike-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smalltailspike-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smalltailspike-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largetailspike-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largetailspike-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smallnosecone-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_smallnosecone-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largenosecone-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_largenosecone-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_mechhead-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_mechhead-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_screwgreeble-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_screwgreeble-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_pan9k-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_pan9k-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_pan9a-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_pan9a-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-paint_diagcube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-paint_diagcube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-paint_halfcube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-paint_halfcube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_ventcube-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-alpha_ventcube-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_vent_long-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_vent_long-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate6-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate6-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate7-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate7-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate8-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate8-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate15-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate15-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate16-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate16-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate10-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate10-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate11-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate11-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate12-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate12-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate13-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate13-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate14-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate14-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate17-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate17-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate18-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate18-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate19-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate19-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate20-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate20-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate21-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate21-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate22-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_stickerplate22-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_0-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_0-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_6-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_6-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_7-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_7-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_8-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_8-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_9-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_9-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_0_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_0_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_1_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_1_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_2_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_2_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_3_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_3_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_4_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_4_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_5_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_5_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_6_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_6_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_7_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_7_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_8_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_8_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_9_m-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_sticker_number_9_m-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_brenn-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_brenn-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_pan-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_pan-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_kip-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_kip-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_snip-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_snip-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_blade-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "block-cosm_dev_blade-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "try-again-later": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "authentication-failure": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "server-lookup-error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "server-connect-error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "transaction-process-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "transaction-process-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "transaction-failed-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "transaction-failed-description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-maxcpu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-maxcosmcpu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-noblocks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-twocore": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-archetype": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-module": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-placement-error-collide": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-advanced-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-advanced-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-cust-held-cosmetic": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-cust-equipped-cosmetics": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-cust-incompatible-part": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-error-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-error-zerocore": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-error-twocore": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-error-maxcpu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-error-maxcosmcpu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-error-disconnect": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "robot-validate-no-functional": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "network-connection-lost-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "network-connection-lost-info": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "matchmaking-failed-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "matchmaking-failed-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "only-host-pick-mode": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "matchmaking-preparing": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "matchmaking-ready": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "matchmaking-estimated": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "paint-premiumonly-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "paint-premiumonly-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-bot-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-bot-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "clipboard-replace-bot-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "clipboard-replace-bot-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-palette-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-palette-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-local-prefab-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-local-prefab-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "import-botfile-message": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-instructions-upload": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-instructions-export": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-instructions-import": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "network-out-of-date-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "network-out-of-date-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-failed-to-join-room": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-failed-join-cause-full": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-failed-join-cause-present": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-failed-join-cause-404": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-failed-join-cause-auth": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-social-status-failure": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-social-status-failure500": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-msg-squadinvite": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-msg-mminvite": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "confirm-user-operation": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-free-for-all": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-contest-capture": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-test": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-desc-free-for-all": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-desc-contest-capture": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-desc-test": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-rules-contest-capture": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-asset-extraction": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-desc-asset-extraction": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "mode-rules-asset-extraction": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "you-have-died": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "respawning-time": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "chat-broadcast": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "replay-save-failed": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dependencies-licenses-credits": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "replay-browser": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "squad-readystate-true": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "squad-readystate-false": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-ok": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-continue": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-cancel": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-reset": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-select": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-remove": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-add": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "ui-button-return": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "clear-prefab-slot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-tech-unlocked": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-be-a-good-influence": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-unknown-tell-devs": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-probably-over-capacity": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-bad-robot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-over-complexity": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "save-error-over-cosmetic-complexity": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "buy-garage": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "buy-garage-cap": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "buy-garage-funds": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "rewards-notification": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-account-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-account-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "delete-account-confirmbody": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dsar-account-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dsar-account-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dsar-account-confirmbody": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "internal-server-error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dsar-query-notfound": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dsar-query-ok": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "account-operation-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "account-operation-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "account-operation-error": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "steam-invite-err-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "steam-invite-err-body": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-mode-build": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-mode-paint": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "build-mode-customize": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-kills": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-deaths": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-assists": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-damagegiven": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-damagetaken": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-damagehealed": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-timeconnected": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-objective": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-objectivepointsgenerated": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "score-objectivepointsscored": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "gameend-exit-match": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "gameend-exiting-in": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "flip-instruction-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "flip-instruction-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "flip-instruction-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "flip-instruction-4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "energy-overdraw-nocharge": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "energy-overdraw-charging": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "asset-extraction-shuttle-approach": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "asset-extraction-shuttle-loading": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "asset-extraction-shuttle-departing": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "asset-extraction-shuttle-abort": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "assetextract-bank-depositing": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "assetextract-bank-stealing": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "match-connecting": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "match-loading": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-1-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-1-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-2-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-2-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-3-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-3-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-4-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-4-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-5-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-5-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-6-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-6-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-51-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-51-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-52-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-52-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-53-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-53-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-54-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-54-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-55-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-55-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-56-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-56-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-101-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-101-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-102-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-102-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-103-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-103-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-104-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-104-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-105-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-105-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-106-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-106-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-107-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-107-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-108-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-108-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-109-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-109-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-110-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-110-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-111-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-111-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-112-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-112-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-113-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-113-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-114-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-114-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-115-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-115-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-116-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-116-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-117-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-117-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-118-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-118-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-201-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-201-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-202-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-202-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-203-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-203-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-204-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-204-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-205-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-205-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-206-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-206-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-207-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-207-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-210-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-210-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-211-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-211-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-212-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-212-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-213-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-213-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-214-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-214-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-251-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-251-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-252-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-252-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-253-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-253-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-254-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-254-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-255-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-255-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-256-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-256-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-257-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-257-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-258-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-258-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-301-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-301-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-302-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-302-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-303-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-303-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-304-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-304-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-305-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-305-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-306-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-306-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-307-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-307-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-326-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-326-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-327-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-327-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-328-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-328-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-329-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-329-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-330-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-330-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-331-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-331-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-332-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-332-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-333-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-333-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-334-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-334-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-335-name": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tech-335-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-name-unknown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-title-unknown": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-name-craig": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-title-craig": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-name-frontiersmen": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-title-frontiersmen": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-name-hypox": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-title-hypox": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-name-tutorialbot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "character-title-tutorialbot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "faction-name-neutral": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "faction-name-osprey": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "faction-name-frontiersmen": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "faction-name-hypox": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-paused-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-paused-message": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tutorial-remove-block-checkbox": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dialogue-click": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dialogue-tasks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "dialogue-dismiss": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-circle-spot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-circle-shoot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-circle-mock": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-circle-kill": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-intro-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-intro-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-intro-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-intro": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-cam": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-bots": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-bots-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-reqtree-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-reqtree-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-reqtree-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-reqtree-4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-guns": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-movement-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-movement-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-inventory-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-inventory-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-garage-movement-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-core": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-deleting-blocks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-deleting-blocks-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-deleting-blocks-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-drive-intro": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-drive-controls": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-drive-waypoint": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-drive-home": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-drive-compass": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-minimap-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-minimap-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-minimap-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-spot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-shooting": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-intro": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-5": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-6": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-7": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-8": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-9": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-10": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-11": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-12": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-13": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-damage-14": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-abilities": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-flip": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-weapon-swap": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-aircraft-intro": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-aircraft-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-aircraft-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-aircraft-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-aircraft-outro": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-outro-1": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-outro-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-outro-3": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "tut-outro-4": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-00": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-01": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-02": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-03": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-04": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-05": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-06": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-07": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-08": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "prefab-desc-09": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0
+    },
+    "information": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "username": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "password": {
+      "size": 32,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "confirm-password": {
+      "size": 32,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "re-enter-password": {
+      "bold": false,
+      "italic": true,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "email-to-reset-password": {
+      "size": 32,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "view-usage-terms-and-privacy-policy": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "i-accept-the-terms-of-usage-and-privacy-policy": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "create-account": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "back-to-login": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "enter-username": {
+      "size": 32,
+      "bold": false,
+      "italic": true,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "enter-passord": {
+      "size": 32,
+      "bold": false,
+      "italic": true,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "remember-me": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "enter-game": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "options": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "exit-game": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "website": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "credits": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-craigy-popup": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "enter-game-steam": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "steam-autologin": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "sign-in-procelio": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "sign-in-options": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "language": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "steamlogin-branch-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "steamlogin-branch-message": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "steamlogin-username-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "steamlogin-username-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "link-steam-account": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "add-standalone-login": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "play-button": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "maindesc-online": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "enter-garage": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "maindesc-garage": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "view-logbook": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "maindesc-logbook": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "mm-tutorialnotice-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        58,
+        189,
+        253
+      ]
+    },
+    "mm-friends-list": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "replays": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "set-username": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "link-steam": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "link-standalone": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "early-access-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "early-access-warning": {
+      "size": 26,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "nf-demo-need-feedback": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "nf-demo-submit-feedback": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "social-menu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "back": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-squad": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "friends-friendlist": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "leave-squad": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "social-squad-invite-code": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "invite-via-steam": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "social-paste-invite-code": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "social-hide-offline-friends": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "social-add-new-friend": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "social-lists": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "friendreq-recv": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "players-blocked": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "queue-squad-friends-list": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "pant-save-palette": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-button-try-join": {
+      "size": 32,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-squad-block": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-squad-kick": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-context-report": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-context-removefriend": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-context-addfriend": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-context-invite": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-context-dm": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chat-context-close-dm": {
+      "size": 18,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "video-tab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "controls-tab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-tab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "audio-tab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-vsync": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "display": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "light-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "colourblindness-mode": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "brightness": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "render-scale": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-general": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "fullscreen": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-preset": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "resolution": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-api": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "fps-limit": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-scale": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "fov": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-visualeffects": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "bloom-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "bloom-intensity": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chroma-aberration-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "chromatic-aberration-intensity": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-advanced": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "model-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "texture-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botdebris-amount": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botdebris-distance": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botdebris-chunks": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "antialiasing-mode": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "dynamicresolution": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shadow-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ambient-occlusion-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "screen-space-reflections": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-ssao": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-volumetric-fog": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-experimental": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "graphics-distortion-data": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-reflection-probes": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "screen-space-global-illumination": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "motion-blur-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-motion-vectors": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-no-decals": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-refraction-data": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "graphics-bad-transparency": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "sss-quality": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "return": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "apply-changes": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "description": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "video-setting-description-template": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "video-recommendation": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "system-log": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "settings-control-profile": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "controls-mouse-settings": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "invert-mouse-y-build": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "invert-mouse-y-drive": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "mouse-sensitivity-garage": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "mouse-sensitivity-drive": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "zoom-sensitivity-zoom": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "controls-part-behaviors": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "tank-sprint-toggle": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "controls-keybindings": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "keybinds-garage": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "keybinds-drive": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "keybinds-interface": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "keybinds-misc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "press-any-key": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "set-to-default": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "setting-join-globalchat": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-testmode": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "test-environment": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-aiamount": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-aiaccuracy": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-aidistance": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-visuals": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "settings-screenshake": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-enhancedcamera": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-motionsickness": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-reduceuimotion": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-gaussboresight": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-enable-dithering": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-speedunits": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-buildmode": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "garage-material": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "garage-background-login-error": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "ui-do-autopurchase": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-build-widgets": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-gizmo-collider": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-gizmo-lift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-gizmo-thrust": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-gizmo-mass": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "settings-undolog": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "game-replay": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "ui-save-matches": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "records-path": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-client-physics": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-game-async-load": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "audio-general": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "master-volume": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "sound-effects-volume": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "environmental-volume": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "music-volume": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-audio-disableMissileAlarm": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "audio-music-selector": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "game-area": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "inventory-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shop-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "battle-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "test-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "tech-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "paint-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "currency-info-normal-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "currency-info-normal-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "currency-info-premium-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        63,
+        129,
+        190
+      ]
+    },
+    "currency-info-premium-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "credit-cap-warning-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "credit-cap-warning-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "max-amp-exceeded": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "return-to-main-menu": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "garage-customization": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "friends": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefabs-menu-button": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "clipboard-copy": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "clipboard-paste": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "copy-bot": {
+      "bold": true,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 2,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "copy-bot-clipboard": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "robot-name": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "configure-bot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "edit-bot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "delete-bot": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "configure-garage-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "configure-garage-screens": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "configure-garage-map": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "configure-garage-bots": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "configure-robot-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "bot-remaps-global": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "bot-control-remapping": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "bot-control-remapping-reset": {
+      "size": 27,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "bot-control-remapping-instructions": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "chat-server-connection-lost": {
+      "size": 24,
+      "bold": false,
+      "italic": true,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "reward-screen-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "ui-dialogue-continue": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "hud-module-dead": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-stat-hp": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-stat-": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-stat-barrier": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        155,
+        0,
+        253
+      ]
+    },
+    "dashboard-stat-invincible": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        62,
+        199,
+        62
+      ]
+    },
+    "dashboard-stat-thrust": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        62,
+        199,
+        62
+      ]
+    },
+    "dashboard-stat-chaff": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        62,
+        199,
+        62
+      ]
+    },
+    "dashboard-stat-damage-vulnerable": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-stat-healbane": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-stat-overdraw": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-stat-oob": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "dashboard-meter-": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "dashboard-meter-collective": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "dashboard-meter-lta": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "flip-instruction-completed": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        207,
+        117,
+        0
+      ]
+    },
+    "return-to-battle-warning": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "oob-terminated": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 8,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "oob-standby": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 2,
+      "color": [
+        180,
+        83,
+        0
+      ]
+    },
+    "oob-uplink-killed": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "oob-console": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "oob-uplink": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "respawn-console": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "oob-disconnected": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 8,
+      "color": [
+        180,
+        83,
+        0
+      ]
+    },
+    "oob-username": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "oob-lastlocation": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "respawn-redeployment": {
+      "size": 32,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "bot-deck-active": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "bot-deck-queued": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "online-battles-not-paused": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 2,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "return-to-game": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "self-destruct": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "quit-to-garage": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "language-settings-title": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "translation-download": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "translation-installed": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "translation-enabled": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "translation-disabled": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "paint-menu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "PAINT-PALETTES": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "paint-create-palette": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "paint-palette-equipped": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 7,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "pant-open-paint-tool": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "add-to-palette": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "copy-palette-color": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "delete-palette-color": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "check-dsar": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "request-dsar": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "delete-account": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "license": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "replay-warning": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "view-replay": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook-title": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook-tutorial": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook-parts": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook-locations": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook-history": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "logbook-factions": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "logbook-player-stats": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "queue-step3-squad": {
+      "size": 36,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "queue-ready-up": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 7,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-squad-not-ready": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "queue-squad-wait-for-host": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "queue-queue-for-match": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-step2-botselect": {
+      "size": 36,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "queue-robotselector-tab-playerbots": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-robotselector-tab-trialbots": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-robotselector-tab-trialbotshint": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        61,
+        130,
+        220
+      ]
+    },
+    "queue-robotselector-hide-invalid": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 7,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-robotselector-remember-deck": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 7,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-robotselector-dropdeck": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "queue-botpicker-warning-1": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "queue-botpicker-warning-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 8,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "gamemode-capture": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gamedesc-capture": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gamemode-asset-extract": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "gamedesc-dm": {
+      "size": 20,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 4,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gamemode-TC": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "queue-gamemode-warning-1": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        40,
+        40,
+        40
+      ]
+    },
+    "queue-gamemode-warning-2": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 8,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "queue-gamemode-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "queue-gamemode-ruleset": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        127,
+        0
+      ]
+    },
+    "queue-gamemode-deselect": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "floating-queue-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "floating-queue=gamemode": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "floating-queue-end-search": {
+      "size": 32,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "menu-button": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "build-open-gizmos": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gizmo-colliders": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gizmo-center-of-lift": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gizmo-center-of-thrust": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "gizmo-center-of-mass": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "toggle-mirror-type": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "toggle-mirror-mode": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "advanced-mode": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "inventory": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shop": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shop-help-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shop-help-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "buy": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "clear": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "autobuy-help-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "techtree-wip": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "techtree-wip-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "techtree-menu": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "need-help-button": {
+      "size": 50,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "need-help": {
+      "size": 27,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "tech-categories": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        116,
+        0
+      ]
+    },
+    "techtree-currentcategory": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "techtree-background-text-2 ": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 2,
+      "color": [
+        0,
+        33,
+        76
+      ]
+    },
+    "techpreview-instructions": {
+      "size": 40,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        128,
+        128,
+        128
+      ]
+    },
+    "techinfo-cat-itemunlocks": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "techinfo-cat-resourceawards": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "award-new-garage-bay": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "award-credits": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "award-premium-currency": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "techinfo-cat-prefabunlocks": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "techinfo-cat-garageunlocks": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "techinfo-cat-testunlocks": {
+      "size": 28,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "techtree-error-cost": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "techtree-error-unlocked": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        62,
+        199,
+        62
+      ]
+    },
+    "unlock-tech-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "unlock-tech-cancel": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "unlock-tech-confirm": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "tech-help-title": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 5,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "tech-help-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "tech-help-return": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "exit-test-mode": {
+      "size": 38,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "toggle-damage-tester": {
+      "size": 24,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "damagetest-weapon-select": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "dmg-test-scale": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "damagetest-damage-scale": {
+      "size": 22,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-source": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "remove-online-prefab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-source-personal": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-source-friends": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-source-unlocked": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-source-all": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefabs-search-prefabs": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "prefab-local-export": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 8,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-cloud-upload": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 8,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shared-prefabs-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "shared-prefabs-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "upload-online-prefab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefabs-search-BOTS": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        117,
+        0
+      ]
+    },
+    "import-prefab": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-import-only-available-parts": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-warning-overamp": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        62,
+        199,
+        62
+      ]
+    },
+    "prefab-warning-invalid": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "prefab-warning-cosmetics": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "prefab-warning-premium": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "prefab-error-parts-unpurchased": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "prefab-error-parts-unavailable": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "prefab-error-parts-locked": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "prefab-error-cost": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "prefab-error-failsafe": {
+      "size": 30,
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        254,
+        56,
+        56
+      ]
+    },
+    "confirm-prefab-import": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "confirm-prefab-import-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "dialogue-succes": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "prefab-export-confirmation": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botfileimport-button": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botfile-import-header": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botfile-import-subheader": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    },
+    "botfile-import-desc": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 10,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botfile-import": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 0,
+      "color": [
+        255,
+        255,
+        255
+      ]
+    },
+    "botfile-import-filepath": {
+      "bold": false,
+      "italic": false,
+      "underline": false,
+      "strikethrough": false,
+      "alignment": 1,
+      "color": [
+        255,
+        162,
+        52
+      ]
+    }
+  }
+}

--- a/templates/glossary.json
+++ b/templates/glossary.json
@@ -1,0 +1,8 @@
+{
+  "meta": {
+    "description": "Glossary and manual overrides for automated translation. by_key wins over by_source_text. post_replace is applied after translation or cache lookup."
+  },
+  "by_key": {},
+  "by_source_text": {},
+  "post_replace": []
+}

--- a/templates/style.json
+++ b/templates/style.json
@@ -1,0 +1,6 @@
+{
+  "meta": {
+    "description": "Optional style overrides applied on top of files/shared_style.json"
+  },
+  "by_key": {}
+}


### PR DESCRIPTION
This PR does multiple things:
1. split language strings from style settings: The style of text is generally set globally, but can be overridden with per-language settings.
2. Add generic templates used by scripts
3. Add a script to bootstrap a language file for new languages/new entries for translations that uses a python library to create an initial translation.
4. Add glossary support for commonly translated terms

The final language file can be generated using another python script

You can see e.g. the glossary in action in #4

If you want me to split the different functions/changes into multiple commits, please let me know :)